### PR TITLE
Support release downloads and remove plugin browser

### DIFF
--- a/ConsoleLog.cs
+++ b/ConsoleLog.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
-using ExileCore2.Shared;
 using ImGuiNET;
 
 namespace PluginUpdater
@@ -32,16 +31,6 @@ namespace PluginUpdater
             }
         }
 
-        public void AddNotificationMessage(string id, string message, Vector4 color)
-        {
-            lock (_logLock)
-            {
-                _logEntries.Add(new LogEntry(message, color));
-            }
-
-            PluginUpdater.Instance.PostNotification(new PluginNotification("", id, message));
-        }
-
         public void LogInfo(string message) =>
             AddLogMessage(message, ColorInfo);
 
@@ -62,7 +51,7 @@ namespace PluginUpdater
             var size = new Vector2(-1, -1);
             ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.2f, 0.2f, 0.2f, 1.0f));
             if (ImGui.BeginChild("##consolelog", size, ImGuiChildFlags.Border,
-                    PluginUpdater.Instance.Settings.WrapLogMessages
+                    PluginUpdater.Instance?.Settings.WrapLogMessages ?? true
                         ? ImGuiWindowFlags.None
                         : ImGuiWindowFlags.HorizontalScrollbar))
             {

--- a/GitUpdater.cs
+++ b/GitUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using ExileCore2;
-using ExileCore2.Shared;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 
@@ -30,11 +28,11 @@ namespace PluginUpdater
         public List<string> AvailableBranches { get; set; } = new();
         public string CurrentBranch { get; set; }
         public string Error { get; set; }
+        public bool IsManualInstall { get; set; }
     }
 
     public class GitUpdater : IDisposable
     {
-        private readonly PluginManager _pluginManager;
         private readonly string _pluginFolder;
         private readonly ConcurrentDictionary<string, PluginInfo> _pluginInfo = new(StringComparer.OrdinalIgnoreCase);
         private CancellationTokenSource _updateCts;
@@ -44,35 +42,38 @@ namespace PluginUpdater
         private void ReportProgress(int current, int total) => ProgressChanged?.Invoke(current, total);
 
         private IEnumerable<PluginInfo> GetGitPlugins() =>
-            Directory.GetDirectories(_pluginFolder).Select(x =>
-            {
-                var resolvedPath = PluginManager.ResolvePluginDirectory(x);
-                var gitPath = Path.Join(resolvedPath, ".git");
-                if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            Directory.GetDirectories(_pluginFolder)
+                .Select(resolvedPath =>
                 {
-                    return CreatePluginInfo(Path.GetFileName(x), resolvedPath);
-                }
+                    var gitPath = Path.Join(resolvedPath, ".git");
+                    if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                    {
+                        return CreatePluginInfo(Path.GetFileName(resolvedPath), resolvedPath);
+                    }
 
-                return null;
-            }).Where(p => p != null);
+                    return null;
+                })
+                .Where(p => p != null);
 
         public IEnumerable<PluginInfo> GetManualPlugins() =>
-            Directory.GetDirectories(_pluginFolder).Select(x =>
-            {
-                var resolvedPath = PluginManager.ResolvePluginDirectory(x);
-                var gitPath = Path.Join(resolvedPath, ".git");
-                if (!Directory.Exists(gitPath) && !File.Exists(gitPath))
+            Directory.GetDirectories(_pluginFolder)
+                .Select(resolvedPath =>
                 {
-                    return CreatePluginInfo(Path.GetFileName(x), resolvedPath);
-                }
+                    var gitPath = Path.Join(resolvedPath, ".git");
+                    if (!Directory.Exists(gitPath) && !File.Exists(gitPath))
+                    {
+                        var pluginInfo = CreatePluginInfo(Path.GetFileName(resolvedPath), resolvedPath);
+                        pluginInfo.IsManualInstall = true;
+                        return pluginInfo;
+                    }
 
-                return null;
-            }).Where(p => p != null);
+                    return null;
+                })
+                .Where(p => p != null);
 
-        public GitUpdater(PluginManager pluginManager)
+        public GitUpdater(string pluginFolder)
         {
-            _pluginManager = pluginManager;
-            _pluginFolder = pluginManager.SourcePluginDirectoryPath;
+            _pluginFolder = pluginFolder;
             UpdateLocal();
         }
 
@@ -97,9 +98,11 @@ namespace PluginUpdater
                 }
                 catch (Exception e)
                 {
-                    DebugWindow.LogError($"Error processing {pluginInfo.Path}: {e}");
+                    PluginLogger.Error($"Error processing {pluginInfo.Path}: {e}");
                 }
             }
+
+            AddManualPlugins();
         }
 
         public async Task UpdateGitInfoAsync()
@@ -123,7 +126,7 @@ namespace PluginUpdater
                 catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
-                    DebugWindow.LogError($"Error during task cancellation: {ex.Message}");
+                    PluginLogger.Error($"Error during task cancellation: {ex.Message}");
                 }
             }
 
@@ -136,11 +139,11 @@ namespace PluginUpdater
             }
             catch (OperationCanceledException)
             {
-                DebugWindow.LogMsg("Git update operation was cancelled");
+                PluginLogger.Info("Git update operation was cancelled");
             }
             catch (Exception ex)
             {
-                DebugWindow.LogError($"Error during git update: {ex.Message}");
+                PluginLogger.Error($"Error during git update: {ex.Message}");
                 throw;
             }
         }
@@ -275,7 +278,7 @@ namespace PluginUpdater
                 }
                 catch (Exception e)
                 {
-                    DebugWindow.LogError($"Error processing {pluginInfo.Path}: {e}");
+                    PluginLogger.Error($"Error processing {pluginInfo.Path}: {e}");
                     pluginInfo.Error = e.Message;
                     if (_pluginInfo.ContainsKey(pluginInfo.Name))
                     {
@@ -294,6 +297,8 @@ namespace PluginUpdater
                     ReportProgress(currentFolder, totalFolders);
                 }
             }
+
+            AddManualPlugins();
         }
 
         public async Task RevertPluginAsync(string pluginName)
@@ -302,7 +307,9 @@ namespace PluginUpdater
             if (folder == null) return;
 
             var plugin = _pluginInfo.GetValueOrDefault(pluginName);
-            if (plugin == null) return;
+            if (plugin == null || plugin.IsManualInstall) return;
+
+            PluginLifecycleHelper.TryUnloadPlugin(pluginName);
 
             await Task.Run(() =>
             {
@@ -314,13 +321,13 @@ namespace PluginUpdater
                     plugin.LastMessage = $"Reset to parent commit {parent.Sha[..7]}";
                     SetPluginInfo(plugin, repo);
 
-                    DebugWindow.LogMsg($"{folder.Path} reverted to {plugin.CurrentCommit}");
-                    DebugWindow.LogMsg(plugin.LastMessage);
+                    PluginLogger.Info($"{folder.Path} reverted to {plugin.CurrentCommit}");
+                    PluginLogger.Info(plugin.LastMessage);
                 }
                 catch (Exception ex)
                 {
                     var errorMsg = $"Error reverting plugin {pluginName}: {ex}";
-                    DebugWindow.LogError(errorMsg);
+                    PluginLogger.Error(errorMsg);
                     throw;
                 }
             });
@@ -332,7 +339,9 @@ namespace PluginUpdater
             if (folder == null) return;
 
             var plugin = _pluginInfo.GetValueOrDefault(pluginName);
-            if (plugin == null) return;
+            if (plugin == null || plugin.IsManualInstall) return;
+
+            PluginLifecycleHelper.TryUnloadPlugin(pluginName);
 
             await Task.Run(() =>
             {
@@ -359,12 +368,12 @@ namespace PluginUpdater
 
                     SetPluginInfo(plugin, repo);
 
-                    DebugWindow.LogMsg($"{folder.Path} updated to {plugin.CurrentCommit}");
-                    DebugWindow.LogMsg(plugin.LastMessage);
+                    PluginLogger.Info($"{folder.Path} updated to {plugin.CurrentCommit}");
+                    PluginLogger.Info(plugin.LastMessage);
                 }
                 catch (Exception ex)
                 {
-                    DebugWindow.LogError($"Error updating plugin {pluginName}: {ex}");
+                    PluginLogger.Error($"Error updating plugin {pluginName}: {ex}");
                     throw;
                 }
             });
@@ -376,7 +385,9 @@ namespace PluginUpdater
             if (folder == null) return;
 
             var plugin = _pluginInfo.GetValueOrDefault(pluginName);
-            if (plugin == null) return;
+            if (plugin == null || plugin.IsManualInstall) return;
+
+            PluginLifecycleHelper.TryUnloadPlugin(pluginName);
 
             await Task.Run(() =>
             {
@@ -405,12 +416,12 @@ namespace PluginUpdater
 
                     SetPluginInfo(plugin, repo);
 
-                    DebugWindow.LogMsg($"{folder.Path} updated to {plugin.CurrentCommit}");
-                    DebugWindow.LogMsg(plugin.LastMessage);
+                    PluginLogger.Info($"{folder.Path} updated to {plugin.CurrentCommit}");
+                    PluginLogger.Info(plugin.LastMessage);
                 }
                 catch (Exception ex)
                 {
-                    DebugWindow.LogError($"Error updating plugin {pluginName}: {ex}");
+                    PluginLogger.Error($"Error updating plugin {pluginName}: {ex}");
                     throw;
                 }
             });
@@ -520,7 +531,7 @@ namespace PluginUpdater
                         }
                         catch (Exception ex)
                         {
-                            DebugWindow.LogError($"Unable to delete {targetPath}: {ex}");
+                            PluginLogger.Error($"Unable to delete {targetPath}: {ex}");
                         }
                     }
                     throw;
@@ -537,10 +548,10 @@ namespace PluginUpdater
 
             try
             {
+                PluginLifecycleHelper.TryUnloadPlugin(pluginName);
+
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-
-                using (var repo = new Repository(pluginPath)) { }
 
                 foreach (var file in Directory.GetFiles(pluginPath, "*.*", SearchOption.AllDirectories))
                     File.SetAttributes(file, FileAttributes.Normal);
@@ -555,6 +566,14 @@ namespace PluginUpdater
             catch (Exception ex)
             {
                 throw new Exception($"Failed to delete plugin: {ex.Message}", ex);
+            }
+        }
+
+        private void AddManualPlugins()
+        {
+            foreach (var manualPlugin in GetManualPlugins())
+            {
+                _pluginInfo[manualPlugin.Name] = manualPlugin;
             }
         }
 
@@ -618,13 +637,13 @@ namespace PluginUpdater
             }
             catch (Exception ex)
             {
-                DebugWindow.LogError($"Unable to retrieve credentials for {url}: {ex}");
+                PluginLogger.Error($"Unable to retrieve credentials for {url}: {ex}");
                 return new DefaultCredentials();
             }
 
             if (username == null || password == null)
             {
-                DebugWindow.LogError($"Unable to retrieve credentials for {url}");
+                PluginLogger.Error($"Unable to retrieve credentials for {url}");
                 return new DefaultCredentials();
             }
 
@@ -638,7 +657,14 @@ namespace PluginUpdater
         public async Task ChangeBranchAsync(PluginInfo plugin, string branchName)
         {
             var pluginPath = plugin.Path;
-            
+
+            if (plugin.IsManualInstall)
+            {
+                throw new InvalidOperationException($"Plugin {plugin.Name} was installed from a release archive and cannot switch branches.");
+            }
+
+            PluginLifecycleHelper.TryUnloadPlugin(plugin.Name);
+
             await Task.Run(() =>
             {
                 using var repo = new Repository(pluginPath);

--- a/GitUpdater.cs
+++ b/GitUpdater.cs
@@ -543,9 +543,7 @@ namespace PluginUpdater
             try
             {
                 PluginLifecycleHelper.TryUnloadPlugin(pluginName);
-
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
+                PluginLifecycleHelper.EnsureAssembliesReleased();
 
                 foreach (var file in Directory.GetFiles(pluginPath, "*.*", SearchOption.AllDirectories))
                     File.SetAttributes(file, FileAttributes.Normal);

--- a/GitUpdater.cs
+++ b/GitUpdater.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 
@@ -109,21 +108,16 @@ namespace PluginUpdater
         {
             if (_updateTask != null && !_updateTask.IsCompleted)
             {
-                var result = MessageBox.Show(
-                    "Update in progress, do you want to restart?",
-                    "Update in progress",
-                    MessageBoxButtons.YesNo);
-
-                if (result == DialogResult.No)
-                    return;
-
+                PluginLogger.Info("An update is already running; cancelling before starting a new one.");
                 _updateCts?.Cancel();
 
                 try
                 {
                     await Task.WhenAny(_updateTask, Task.Delay(5000));
                 }
-                catch (OperationCanceledException) { }
+                catch (OperationCanceledException)
+                {
+                }
                 catch (Exception ex)
                 {
                     PluginLogger.Error($"Error during task cancellation: {ex.Message}");

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Loader;
@@ -96,9 +95,8 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
-            var knownNames = new HashSet<string>(PManager.Plugins.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
-
-            if (!PManager.LoadPlugin(pluginName))
+            var plugin = PManager.LoadPlugin(directoryInfo);
+            if (plugin == null)
             {
                 var message = $"GameHelper failed to load plugin from {directoryInfo.FullName}.";
                 consoleLog?.LogWarning(message);
@@ -106,20 +104,25 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
+            PManager.LoadPluginMetadata(new[] { plugin });
+
             var container = PManager.Plugins.FirstOrDefault(
-                plugin => plugin != null && !knownNames.Contains(plugin.Name));
+                candidate => candidate != null &&
+                              candidate.Name.Equals(plugin.Name, StringComparison.OrdinalIgnoreCase));
 
-            container ??= PManager.Plugins.FirstOrDefault(
-                plugin => plugin != null &&
-                          plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
-
-            if (container != null)
+            if (container == null)
             {
-                container.Metadata.Enable = true;
-                PManager.SavePluginMetadata();
+                var message = $"Loaded assembly for {plugin.Name} but plugin container was not registered.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Warn(message);
+                return false;
             }
 
-            var successMessage = $"Loaded plugin {pluginName} after file operations.";
+            container.Metadata.Enable = true;
+            PManager.SavePluginMetadata();
+            container.Plugin.OnEnable(Core.Process.Address != IntPtr.Zero);
+
+            var successMessage = $"Loaded plugin {plugin.Name} after file operations.";
             consoleLog?.LogInfo(successMessage);
             PluginLogger.Info(successMessage);
             return true;

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -120,7 +120,7 @@ internal static class PluginLifecycleHelper
 
             container.Metadata.Enable = true;
             PManager.SavePluginMetadata();
-            container.Plugin.OnEnable(Core.Process.Address != IntPtr.Zero);
+            container.Plugin.OnEnable(Core.States.Address != IntPtr.Zero);
 
             var successMessage = $"Loaded plugin {plugin.Name} after file operations.";
             consoleLog?.LogInfo(successMessage);

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Loader;
 using GameHelper;
 using GameHelper.Plugin;
 
@@ -22,9 +23,12 @@ internal static class PluginLifecycleHelper
                 plugin => plugin != null &&
                           plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
 
+            AssemblyLoadContext loadContext = null;
+
             if (container != null)
             {
                 container.Metadata.Enable = false;
+                loadContext = AssemblyLoadContext.GetLoadContext(container.Plugin.GetType().Assembly);
             }
 
             if (!PManager.UnloadPlugin(pluginName))
@@ -32,6 +36,7 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
+            TryUnloadAssemblyContext(pluginName, loadContext, consoleLog);
             PManager.SavePluginMetadata();
             EnsureAssembliesReleased();
 
@@ -46,6 +51,33 @@ internal static class PluginLifecycleHelper
             consoleLog?.LogError(message);
             PluginLogger.Error(message);
             return false;
+        }
+    }
+
+    private static void TryUnloadAssemblyContext(string pluginName, AssemblyLoadContext context, ConsoleLog consoleLog)
+    {
+        if (context == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!context.IsCollectible)
+            {
+                var message = $"Plugin {pluginName} is loaded in a non-collectible context and cannot be fully unloaded.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Warn(message);
+                return;
+            }
+
+            context.Unload();
+        }
+        catch (Exception ex)
+        {
+            var message = $"Failed to unload AssemblyLoadContext for {pluginName}: {ex.Message}";
+            consoleLog?.LogWarning(message);
+            PluginLogger.Warn(message);
         }
     }
 

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections;
 using System.IO;
-using System.Reflection;
+using System.Linq;
+using GameHelper;
 using GameHelper.Plugin;
 
 namespace PluginUpdater;
@@ -17,47 +17,18 @@ internal static class PluginLifecycleHelper
 
         try
         {
-            if (!TryGetPluginManagerType(out var pluginManagerType))
-            {
-                var message = "Unable to locate GameHelper plugin manager; cannot unload plugin automatically.";
-                consoleLog?.LogWarning(message);
-                PluginLogger.Warn(message);
-                return false;
-            }
+            var container = PManager.Plugins.FirstOrDefault(
+                plugin => plugin != null &&
+                          plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
 
-            var pluginsField = pluginManagerType.GetField(
-                "Plugins",
-                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
-
-            if (pluginsField?.GetValue(null) is not IList plugins || plugins.Count == 0)
+            if (container == null)
             {
                 return false;
             }
 
-            object targetContainer = null;
-            foreach (var container in plugins)
-            {
-                var nameProperty = container?.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
-                var name = nameProperty?.GetValue(container) as string;
-                if (!string.IsNullOrWhiteSpace(name) && name.Equals(pluginName, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetContainer = container;
-                    break;
-                }
-            }
-
-            if (targetContainer == null)
-            {
-                return false;
-            }
-
-            var pluginProperty = targetContainer.GetType().GetProperty("Plugin", BindingFlags.Instance | BindingFlags.Public);
-            var pluginInstance = pluginProperty?.GetValue(targetContainer) as IPCore;
-
-            pluginInstance?.SaveSettings();
-            pluginInstance?.OnDisable();
-
-            plugins.Remove(targetContainer);
+            container.Plugin.SaveSettings();
+            container.Plugin.OnDisable();
+            PManager.Plugins.Remove(container);
 
             var successMessage = $"Unloaded plugin {pluginName} before file operations.";
             consoleLog?.LogInfo(successMessage);
@@ -82,46 +53,13 @@ internal static class PluginLifecycleHelper
 
         try
         {
-            if (!TryGetPluginManagerType(out var pluginManagerType))
-            {
-                var message = "Unable to locate GameHelper plugin manager; cannot load plugin automatically.";
-                consoleLog?.LogWarning(message);
-                PluginLogger.Warn(message);
-                return false;
-            }
-
-            var pluginsField = pluginManagerType.GetField(
-                "Plugins",
-                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
-
-            var loadPluginMethod = pluginManagerType.GetMethod(
-                "LoadPlugin",
-                BindingFlags.Static | BindingFlags.NonPublic,
-                binder: null,
-                types: new[] { typeof(DirectoryInfo) },
-                modifiers: null);
-
-            var loadMetadataMethod = pluginManagerType.GetMethod(
-                "LoadPluginMetadata",
-                BindingFlags.Static | BindingFlags.NonPublic);
-
-            var pluginWithNameType = pluginManagerType.Assembly.GetType("GameHelper.Plugin.PluginWithName");
-
-            if (pluginsField == null || loadPluginMethod == null || loadMetadataMethod == null || pluginWithNameType == null)
-            {
-                var message = "Unable to access GameHelper internals required to load plugins automatically.";
-                consoleLog?.LogWarning(message);
-                PluginLogger.Warn(message);
-                return false;
-            }
-
             var directoryInfo = new DirectoryInfo(pluginDirectory);
             if (!directoryInfo.Exists)
             {
                 return false;
             }
 
-            var pluginWithName = loadPluginMethod.Invoke(null, new object[] { directoryInfo });
+            var pluginWithName = PManager.LoadPlugin(directoryInfo);
             if (pluginWithName == null)
             {
                 var message = $"GameHelper failed to load plugin from {directoryInfo.FullName}.";
@@ -130,48 +68,25 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
-            var pluginArray = Array.CreateInstance(pluginWithNameType, 1);
-            pluginArray.SetValue(pluginWithName, 0);
-            loadMetadataMethod.Invoke(null, new object[] { pluginArray });
+            PManager.LoadPluginMetadata(new[] { pluginWithName });
 
-            var recordedNameProperty = pluginWithNameType.GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
-            var recordedName = recordedNameProperty?.GetValue(pluginWithName) as string;
-            var resolvedPluginName = !string.IsNullOrWhiteSpace(recordedName) ? recordedName : pluginName;
+            var resolvedName = string.IsNullOrWhiteSpace(pluginWithName.Name)
+                ? pluginName
+                : pluginWithName.Name;
 
-            if (pluginsField.GetValue(null) is not IList plugins || plugins.Count == 0)
+            var container = PManager.Plugins.FirstOrDefault(
+                plugin => plugin != null &&
+                          plugin.Name.Equals(resolvedName, StringComparison.OrdinalIgnoreCase));
+
+            if (container == null)
             {
                 return false;
             }
 
-            object targetContainer = null;
-            foreach (var container in plugins)
-            {
-                var nameProperty = container?.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
-                var name = nameProperty?.GetValue(container) as string;
-                if (!string.IsNullOrWhiteSpace(name) &&
-                    name.Equals(resolvedPluginName, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetContainer = container;
-                    break;
-                }
-            }
+            container.Metadata.Enable = true;
+            container.Plugin.OnEnable(Core.Process.Address != IntPtr.Zero);
 
-            if (targetContainer == null)
-            {
-                return false;
-            }
-
-            var metadataProperty = targetContainer.GetType().GetProperty("Metadata", BindingFlags.Instance | BindingFlags.Public);
-            var metadata = metadataProperty?.GetValue(targetContainer);
-            var enableProperty = metadata?.GetType().GetProperty("Enable", BindingFlags.Instance | BindingFlags.Public);
-            enableProperty?.SetValue(metadata, true);
-
-            var pluginProperty = targetContainer.GetType().GetProperty("Plugin", BindingFlags.Instance | BindingFlags.Public);
-            var pluginInstance = pluginProperty?.GetValue(targetContainer) as IPCore;
-
-            pluginInstance?.OnEnable(IsGameLoaded());
-
-            var successMessage = $"Loaded plugin {resolvedPluginName} after file operations.";
+            var successMessage = $"Loaded plugin {container.Name} after file operations.";
             consoleLog?.LogInfo(successMessage);
             PluginLogger.Info(successMessage);
             return true;
@@ -183,42 +98,5 @@ internal static class PluginLifecycleHelper
             PluginLogger.Error(message);
             return false;
         }
-    }
-
-    private static bool TryGetPluginManagerType(out Type pluginManagerType)
-    {
-        pluginManagerType = Type.GetType("GameHelper.Plugin.PManager, GameHelper");
-        return pluginManagerType != null;
-    }
-
-    private static bool IsGameLoaded()
-    {
-        try
-        {
-            var coreType = Type.GetType("GameHelper.Core, GameHelper");
-            if (coreType == null)
-            {
-                return false;
-            }
-
-            var processProperty = coreType.GetProperty("Process", BindingFlags.Static | BindingFlags.Public);
-            var processInstance = processProperty?.GetValue(null);
-            if (processInstance == null)
-            {
-                return false;
-            }
-
-            var addressProperty = processInstance.GetType().GetProperty("Address", BindingFlags.Instance | BindingFlags.Public);
-            if (addressProperty?.GetValue(processInstance) is IntPtr address)
-            {
-                return address != IntPtr.Zero;
-            }
-        }
-        catch (Exception ex)
-        {
-            PluginLogger.Warn($"Unable to determine game load state: {ex.Message}");
-        }
-
-        return false;
     }
 }

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using GameHelper.Plugin;
+
+namespace PluginUpdater;
+
+internal static class PluginLifecycleHelper
+{
+    public static bool TryUnloadPlugin(string pluginName, ConsoleLog consoleLog = null)
+    {
+        if (string.IsNullOrWhiteSpace(pluginName))
+        {
+            return false;
+        }
+
+        try
+        {
+            var pluginNames = PManager.PluginNames?.ToList();
+            if (pluginNames == null || pluginNames.Count == 0)
+            {
+                return false;
+            }
+
+            var match = pluginNames.FirstOrDefault(name =>
+                name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                return false;
+            }
+
+            if (!PManager.UnloadPlugin(match))
+            {
+                var message = $"Failed to unload plugin {pluginName} before file operations.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Info(message);
+                return false;
+            }
+
+            var successMessage = $"Unloaded plugin {pluginName} before file operations.";
+            consoleLog?.LogInfo(successMessage);
+            PluginLogger.Info(successMessage);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            var message = $"Unable to unload plugin {pluginName}: {ex.Message}";
+            consoleLog?.LogError(message);
+            PluginLogger.Error(message);
+            return false;
+        }
+    }
+}

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using GameHelper;
@@ -17,18 +18,10 @@ internal static class PluginLifecycleHelper
 
         try
         {
-            var container = PManager.Plugins.FirstOrDefault(
-                plugin => plugin != null &&
-                          plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
-
-            if (container == null)
+            if (!PManager.UnloadPlugin(pluginName))
             {
                 return false;
             }
-
-            container.Plugin.SaveSettings();
-            container.Plugin.OnDisable();
-            PManager.Plugins.Remove(container);
 
             var successMessage = $"Unloaded plugin {pluginName} before file operations.";
             consoleLog?.LogInfo(successMessage);
@@ -59,8 +52,9 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
-            var pluginWithName = PManager.LoadPlugin(directoryInfo);
-            if (pluginWithName == null)
+            var knownNames = new HashSet<string>(PManager.Plugins.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+
+            if (!PManager.LoadPlugin(pluginName))
             {
                 var message = $"GameHelper failed to load plugin from {directoryInfo.FullName}.";
                 consoleLog?.LogWarning(message);
@@ -68,25 +62,20 @@ internal static class PluginLifecycleHelper
                 return false;
             }
 
-            PManager.LoadPluginMetadata(new[] { pluginWithName });
-
-            var resolvedName = string.IsNullOrWhiteSpace(pluginWithName.Name)
-                ? pluginName
-                : pluginWithName.Name;
-
             var container = PManager.Plugins.FirstOrDefault(
-                plugin => plugin != null &&
-                          plugin.Name.Equals(resolvedName, StringComparison.OrdinalIgnoreCase));
+                plugin => plugin != null && !knownNames.Contains(plugin.Name));
 
-            if (container == null)
+            container ??= PManager.Plugins.FirstOrDefault(
+                plugin => plugin != null &&
+                          plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
+
+            if (container != null)
             {
-                return false;
+                container.Metadata.Enable = true;
+                PManager.SavePluginMetadata();
             }
 
-            container.Metadata.Enable = true;
-            container.Plugin.OnEnable(Core.Process.Address != IntPtr.Zero);
-
-            var successMessage = $"Loaded plugin {container.Name} after file operations.";
+            var successMessage = $"Loaded plugin {pluginName} after file operations.";
             consoleLog?.LogInfo(successMessage);
             PluginLogger.Info(successMessage);
             return true;

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -18,10 +18,22 @@ internal static class PluginLifecycleHelper
 
         try
         {
+            var container = PManager.Plugins.FirstOrDefault(
+                plugin => plugin != null &&
+                          plugin.Name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
+
+            if (container != null)
+            {
+                container.Metadata.Enable = false;
+            }
+
             if (!PManager.UnloadPlugin(pluginName))
             {
                 return false;
             }
+
+            PManager.SavePluginMetadata();
+            EnsureAssembliesReleased();
 
             var successMessage = $"Unloaded plugin {pluginName} before file operations.";
             consoleLog?.LogInfo(successMessage);
@@ -86,6 +98,20 @@ internal static class PluginLifecycleHelper
             consoleLog?.LogError(message);
             PluginLogger.Error(message);
             return false;
+        }
+    }
+
+    public static void EnsureAssembliesReleased()
+    {
+        try
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+        catch (Exception ex)
+        {
+            PluginLogger.Warn($"Failed to force GC while releasing plugin assemblies: {ex.Message}");
         }
     }
 }

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Linq;
+using System.Collections;
+using System.Reflection;
 using GameHelper.Plugin;
 
 namespace PluginUpdater;
@@ -15,27 +16,48 @@ internal static class PluginLifecycleHelper
 
         try
         {
-            var pluginNames = PManager.PluginNames?.ToList();
-            if (pluginNames == null || pluginNames.Count == 0)
+            var pluginManagerType = Type.GetType("GameHelper.Plugin.PManager, GameHelper");
+            if (pluginManagerType == null)
             {
-                return false;
-            }
-
-            var match = pluginNames.FirstOrDefault(name =>
-                name.Equals(pluginName, StringComparison.OrdinalIgnoreCase));
-
-            if (match == null)
-            {
-                return false;
-            }
-
-            if (!PManager.UnloadPlugin(match))
-            {
-                var message = $"Failed to unload plugin {pluginName} before file operations.";
+                var message = "Unable to locate GameHelper plugin manager; cannot unload plugin automatically.";
                 consoleLog?.LogWarning(message);
-                PluginLogger.Info(message);
+                PluginLogger.Warn(message);
                 return false;
             }
+
+            var pluginsField = pluginManagerType.GetField(
+                "Plugins",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (pluginsField?.GetValue(null) is not IList plugins || plugins.Count == 0)
+            {
+                return false;
+            }
+
+            object targetContainer = null;
+            foreach (var container in plugins)
+            {
+                var nameProperty = container?.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
+                var name = nameProperty?.GetValue(container) as string;
+                if (!string.IsNullOrWhiteSpace(name) && name.Equals(pluginName, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetContainer = container;
+                    break;
+                }
+            }
+
+            if (targetContainer == null)
+            {
+                return false;
+            }
+
+            var pluginProperty = targetContainer.GetType().GetProperty("Plugin", BindingFlags.Instance | BindingFlags.Public);
+            var pluginInstance = pluginProperty?.GetValue(targetContainer) as IPCore;
+
+            pluginInstance?.SaveSettings();
+            pluginInstance?.OnDisable();
+
+            plugins.Remove(targetContainer);
 
             var successMessage = $"Unloaded plugin {pluginName} before file operations.";
             consoleLog?.LogInfo(successMessage);

--- a/PluginLifecycleHelper.cs
+++ b/PluginLifecycleHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.IO;
 using System.Reflection;
 using GameHelper.Plugin;
 
@@ -16,8 +17,7 @@ internal static class PluginLifecycleHelper
 
         try
         {
-            var pluginManagerType = Type.GetType("GameHelper.Plugin.PManager, GameHelper");
-            if (pluginManagerType == null)
+            if (!TryGetPluginManagerType(out var pluginManagerType))
             {
                 var message = "Unable to locate GameHelper plugin manager; cannot unload plugin automatically.";
                 consoleLog?.LogWarning(message);
@@ -71,5 +71,154 @@ internal static class PluginLifecycleHelper
             PluginLogger.Error(message);
             return false;
         }
+    }
+
+    public static bool TryLoadPlugin(string pluginName, string pluginDirectory, ConsoleLog consoleLog = null)
+    {
+        if (string.IsNullOrWhiteSpace(pluginDirectory))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!TryGetPluginManagerType(out var pluginManagerType))
+            {
+                var message = "Unable to locate GameHelper plugin manager; cannot load plugin automatically.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Warn(message);
+                return false;
+            }
+
+            var pluginsField = pluginManagerType.GetField(
+                "Plugins",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            var loadPluginMethod = pluginManagerType.GetMethod(
+                "LoadPlugin",
+                BindingFlags.Static | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(DirectoryInfo) },
+                modifiers: null);
+
+            var loadMetadataMethod = pluginManagerType.GetMethod(
+                "LoadPluginMetadata",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            var pluginWithNameType = pluginManagerType.Assembly.GetType("GameHelper.Plugin.PluginWithName");
+
+            if (pluginsField == null || loadPluginMethod == null || loadMetadataMethod == null || pluginWithNameType == null)
+            {
+                var message = "Unable to access GameHelper internals required to load plugins automatically.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Warn(message);
+                return false;
+            }
+
+            var directoryInfo = new DirectoryInfo(pluginDirectory);
+            if (!directoryInfo.Exists)
+            {
+                return false;
+            }
+
+            var pluginWithName = loadPluginMethod.Invoke(null, new object[] { directoryInfo });
+            if (pluginWithName == null)
+            {
+                var message = $"GameHelper failed to load plugin from {directoryInfo.FullName}.";
+                consoleLog?.LogWarning(message);
+                PluginLogger.Warn(message);
+                return false;
+            }
+
+            var pluginArray = Array.CreateInstance(pluginWithNameType, 1);
+            pluginArray.SetValue(pluginWithName, 0);
+            loadMetadataMethod.Invoke(null, new object[] { pluginArray });
+
+            var recordedNameProperty = pluginWithNameType.GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
+            var recordedName = recordedNameProperty?.GetValue(pluginWithName) as string;
+            var resolvedPluginName = !string.IsNullOrWhiteSpace(recordedName) ? recordedName : pluginName;
+
+            if (pluginsField.GetValue(null) is not IList plugins || plugins.Count == 0)
+            {
+                return false;
+            }
+
+            object targetContainer = null;
+            foreach (var container in plugins)
+            {
+                var nameProperty = container?.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
+                var name = nameProperty?.GetValue(container) as string;
+                if (!string.IsNullOrWhiteSpace(name) &&
+                    name.Equals(resolvedPluginName, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetContainer = container;
+                    break;
+                }
+            }
+
+            if (targetContainer == null)
+            {
+                return false;
+            }
+
+            var metadataProperty = targetContainer.GetType().GetProperty("Metadata", BindingFlags.Instance | BindingFlags.Public);
+            var metadata = metadataProperty?.GetValue(targetContainer);
+            var enableProperty = metadata?.GetType().GetProperty("Enable", BindingFlags.Instance | BindingFlags.Public);
+            enableProperty?.SetValue(metadata, true);
+
+            var pluginProperty = targetContainer.GetType().GetProperty("Plugin", BindingFlags.Instance | BindingFlags.Public);
+            var pluginInstance = pluginProperty?.GetValue(targetContainer) as IPCore;
+
+            pluginInstance?.OnEnable(IsGameLoaded());
+
+            var successMessage = $"Loaded plugin {resolvedPluginName} after file operations.";
+            consoleLog?.LogInfo(successMessage);
+            PluginLogger.Info(successMessage);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            var message = $"Unable to load plugin {pluginName}: {ex.Message}";
+            consoleLog?.LogError(message);
+            PluginLogger.Error(message);
+            return false;
+        }
+    }
+
+    private static bool TryGetPluginManagerType(out Type pluginManagerType)
+    {
+        pluginManagerType = Type.GetType("GameHelper.Plugin.PManager, GameHelper");
+        return pluginManagerType != null;
+    }
+
+    private static bool IsGameLoaded()
+    {
+        try
+        {
+            var coreType = Type.GetType("GameHelper.Core, GameHelper");
+            if (coreType == null)
+            {
+                return false;
+            }
+
+            var processProperty = coreType.GetProperty("Process", BindingFlags.Static | BindingFlags.Public);
+            var processInstance = processProperty?.GetValue(null);
+            if (processInstance == null)
+            {
+                return false;
+            }
+
+            var addressProperty = processInstance.GetType().GetProperty("Address", BindingFlags.Instance | BindingFlags.Public);
+            if (addressProperty?.GetValue(processInstance) is IntPtr address)
+            {
+                return address != IntPtr.Zero;
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginLogger.Warn($"Unable to determine game load state: {ex.Message}");
+        }
+
+        return false;
     }
 }

--- a/PluginLogger.cs
+++ b/PluginLogger.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PluginUpdater;
+
+internal static class PluginLogger
+{
+    public static void Info(string message)
+    {
+        Console.WriteLine($"[PluginUpdater][INFO] {message}");
+    }
+
+    public static void Error(string message)
+    {
+        Console.WriteLine($"[PluginUpdater][ERROR] {message}");
+    }
+}

--- a/PluginLogger.cs
+++ b/PluginLogger.cs
@@ -9,6 +9,11 @@ internal static class PluginLogger
         Console.WriteLine($"[PluginUpdater][INFO] {message}");
     }
 
+    public static void Warn(string message)
+    {
+        Console.WriteLine($"[PluginUpdater][WARN] {message}");
+    }
+
     public static void Error(string message)
     {
         Console.WriteLine($"[PluginUpdater][ERROR] {message}");

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -2,56 +2,21 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading.Tasks;
-using ExileCore2;
-using ExileCore2.Shared.Attributes;
-using ExileCore2.Shared.Interfaces;
 using ImGuiNET;
 
 namespace PluginUpdater
 {
-    public class PluginRepositoryData
-    {
-        public List<PluginDescription> PluginDescriptions { get; set; }
-    }
-
-    public class PluginDescription
-    {
-        public string Name { get; set; }
-        public string OriginalAuthor { get; set; }
-        public List<Fork> Forks { get; set; }
-        public string Description { get; set; }
-        public string EndorsedAuthor { get; set; }
-    }
-
-    public class Fork
-    {
-        public string Author { get; set; }
-        public string Location { get; set; }
-        public string Name { get; set; }
-        public LatestCommit LatestCommit { get; set; }
-        public List<Release> Releases { get; set; }
-    }
-
-    public class LatestCommit
-    {
-        public string Message { get; set; }
-        public string Hash { get; set; }
-        public string Author { get; set; }
-        public string Date { get; set; }
-    }
-
-    public class Release
-    {
-        // the output.json has no data in releases so not sure structure xd
-    }
-
-    [Submenu(RenderMethod = nameof(Render))]
     public class PluginRenderer : IDisposable
     {
         private readonly ConsoleLog _consoleLog = new();
         private readonly PluginUpdaterSettings _settings;
+        private readonly string _pluginRootPath;
         private GitUpdater _updater;
 
         private bool _isUpdating;
@@ -62,21 +27,24 @@ namespace PluginUpdater
         private bool _isUpdatingAll;
         private string _repoUrl = string.Empty;
         private bool _isCloning;
-        private readonly List<PluginDescription> _availablePlugins = [];
-        private readonly Dictionary<string, bool> _downloadingPlugins = [];
-        private bool _isLoadingRepos;
-        private bool _hasLoadedRepos;
-        private string _loadError = string.Empty;
+        private bool _isDownloadingRelease;
+        private readonly Dictionary<string, bool> _releaseReinstalling = new(StringComparer.OrdinalIgnoreCase);
         private DateTime _lastPeriodicCheckAttempt = DateTime.MinValue;
+        private string _pluginToDelete;
 
-        public PluginRenderer(PluginUpdaterSettings settings)
+        private sealed record ReleaseDownloadInfo(string DownloadUrl, string PluginNameFallback, string NormalizedUrl);
+
+        private sealed record ReleaseUrlParts(string Owner, string Repo, string Tag, bool IsDirectAsset, string AssetName);
+
+        public PluginRenderer(PluginUpdaterSettings settings, string pluginRootPath)
         {
             _settings = settings;
+            _pluginRootPath = pluginRootPath;
         }
 
         public void Startup()
         {
-            _updater = new GitUpdater(PluginUpdater.Instance.PluginManager);
+            _updater = new GitUpdater(_pluginRootPath);
             _updater.ProgressChanged += (current, total) =>
             {
                 _currentProgress = current;
@@ -86,7 +54,7 @@ namespace PluginUpdater
             var manuallyDownloadedPlugins = _updater.GetManualPlugins();
             foreach (var plugin in manuallyDownloadedPlugins)
             {
-                _consoleLog.LogWarning($"{Path.GetFileName(plugin.Name)} was downloaded manually so cannot be updated via this plugin");
+                _consoleLog.LogInfo($"{plugin.Name} is managed via release archives. Use the Add tab to redownload when new releases are available.");
             }
 
             if (_settings.CheckUpdatesOnStartup && !_settings.HasCheckedUpdates)
@@ -118,8 +86,6 @@ namespace PluginUpdater
 
             try
             {
-                PluginUpdater.Instance.RemoveNotification("", "PendingUpdates");
-
                 _isUpdating = true;
                 await _updater.UpdateGitInfoAsync();
 
@@ -127,15 +93,15 @@ namespace PluginUpdater
                 int updateCount = plugins.Count(p => p.CurrentCommit != p.LatestCommit);
                 if (updateCount > 0)
                 {
-                    _consoleLog.AddNotificationMessage("PendingUpdates", $"There is {updateCount} plugin {(updateCount > 1 ? "updates" : "update")} pending.",
-                        ConsoleLog.ColorInfo);
+                    var updateLabel = updateCount == 1 ? "update" : "updates";
+                    _consoleLog.LogInfo($"There {(updateCount == 1 ? "is" : "are")} {updateCount} plugin {updateLabel} pending.");
                 }
             }
             catch (Exception e)
             {
                 var errorMsg = $"Error updating git info: {e}";
-                DebugWindow.LogError(errorMsg);
-                _consoleLog.LogError($"{errorMsg}");
+                PluginLogger.Error(errorMsg);
+                _consoleLog.LogError(errorMsg);
             }
             finally
             {
@@ -175,13 +141,12 @@ namespace PluginUpdater
                 }
 
                 _consoleLog.LogSuccess($"Successfully updated {pluginName}");
-                PluginUpdater.Instance.RemoveNotification("", "PendingUpdates");
             }
             catch (Exception e)
             {
                 var errorMsg = $"Error updating plugin {pluginName}: {e.Message}";
-                DebugWindow.LogError(errorMsg);
-                _consoleLog.LogError($"{errorMsg}");
+                PluginLogger.Error(errorMsg);
+                _consoleLog.LogError(errorMsg);
             }
             finally
             {
@@ -197,7 +162,10 @@ namespace PluginUpdater
             {
                 _isUpdatingAll = true;
                 var plugins = _updater.GetPluginInfo();
-                var outdatedPlugins = plugins.Where(p => p.CurrentCommit != p.LatestCommit).ToList();
+                var outdatedPlugins = plugins
+                    .Where(p => !p.IsManualInstall)
+                    .Where(p => p.CurrentCommit != p.LatestCommit)
+                    .ToList();
 
                 _consoleLog.LogInfo($"Starting update for {outdatedPlugins.Count} plugins...");
 
@@ -205,23 +173,20 @@ namespace PluginUpdater
                 {
                     await UpdatePluginAsync(plugin.Name, false);
                 }
-
-                PluginUpdater.Instance.RemoveNotification("", "PendingUpdates");
             }
             catch (Exception e)
             {
-                DebugWindow.LogError($"Error updating all plugins: {e.Message}");
+                PluginLogger.Error($"Error updating all plugins: {e.Message}");
             }
             finally
             {
                 _isUpdatingAll = false;
-                _settings.GameController.Memory.Dispose();
             }
         }
 
-        public void Render()
+        public void DrawSettings()
         {
-            if (!_settings.Enable.Value)
+            if (!_settings.Enable)
                 return;
 
             if (ImGui.BeginTabBar("PluginManagerTabs"))
@@ -231,6 +196,7 @@ namespace PluginUpdater
                     ImGui.Spacing();
                     RenderUpdateButtons();
                     RenderPluginsTable();
+                    RenderDeleteConfirmationModal();
                     ImGui.EndTabItem();
                 }
 
@@ -238,13 +204,6 @@ namespace PluginUpdater
                 {
                     ImGui.Spacing();
                     RenderAddPluginSection();
-                    ImGui.EndTabItem();
-                }
-
-                if (ImGui.BeginTabItem("Browse"))
-                {
-                    ImGui.Spacing();
-                    RenderPluginBrowser();
                     ImGui.EndTabItem();
                 }
 
@@ -263,6 +222,14 @@ namespace PluginUpdater
 
         private void RenderSettings()
         {
+            bool isEnabled = _settings.Enable;
+            if (ImGui.Checkbox("Enable plugin updater", ref isEnabled))
+            {
+                _settings.Enable = isEnabled;
+            }
+
+            ImGui.Spacing();
+
             bool checkStartup = _settings.CheckUpdatesOnStartup;
             if (ImGui.Checkbox("Check for updates on startup", ref checkStartup))
             {
@@ -323,6 +290,7 @@ namespace PluginUpdater
                     ImGui.EndCombo();
                 }
             }
+
         }
 
         private string _pluginNameFilter = "";
@@ -356,7 +324,8 @@ namespace PluginUpdater
                 }
 
                 var plugins = _updater.GetPluginInfo();
-                bool hasUpdates = plugins.Any(p => p.CurrentCommit != p.LatestCommit);
+                var gitPlugins = plugins.Where(p => !p.IsManualInstall).ToList();
+                bool hasUpdates = gitPlugins.Any(p => p.CurrentCommit != p.LatestCommit);
 
                 if (hasUpdates)
                 {
@@ -457,7 +426,7 @@ namespace PluginUpdater
                 }
                 catch (Exception e)
                 {
-                    DebugWindow.LogError($"Error rendering plugin {pluginInfo.Name}: {e.Message}");
+                    PluginLogger.Error($"Error rendering plugin {pluginInfo.Name}: {e.Message}");
                 }
             }
         }
@@ -538,6 +507,22 @@ namespace PluginUpdater
                 return;
             }
 
+            if (pluginInfo.IsManualInstall)
+            {
+                var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                if (releaseSources != null && releaseSources.TryGetValue(pluginInfo.Name, out var source))
+                {
+                    ImGui.TextWrapped($"Installed from release: {source}");
+                }
+                else
+                {
+                    ImGui.TextWrapped("Installed from release archive. Use the Add tab to redownload when updates are available.");
+                }
+
+                ImGui.TableNextColumn();
+                return;
+            }
+
             string text;
             if (string.IsNullOrEmpty(pluginInfo.LatestCommit))
             {
@@ -589,8 +574,8 @@ namespace PluginUpdater
             catch (Exception e)
             {
                 var errorMsg = $"Error reverting plugin {pluginName}: {e.Message}";
-                DebugWindow.LogError(errorMsg);
-                _consoleLog.LogError($"{errorMsg}");
+                PluginLogger.Error(errorMsg);
+                _consoleLog.LogError(errorMsg);
             }
             finally
             {
@@ -600,7 +585,39 @@ namespace PluginUpdater
 
         private void RenderActionButtons(PluginInfo pluginInfo)
         {
-            if (!string.IsNullOrEmpty(pluginInfo.CurrentCommit))
+            if (pluginInfo.IsManualInstall)
+            {
+                var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                var hasSource = releaseSources != null && releaseSources.TryGetValue(pluginInfo.Name, out var releaseUrl) && !string.IsNullOrWhiteSpace(releaseUrl);
+                bool isReinstalling = _releaseReinstalling.TryGetValue(pluginInfo.Name, out bool reinstalling) && reinstalling;
+
+                if (hasSource)
+                {
+                    if (isReinstalling)
+                    {
+                        ImGui.BeginDisabled();
+                        ImGui.Button($"Redownloading...##{pluginInfo.Name}");
+                        ImGui.EndDisabled();
+                    }
+                    else if (ImGui.Button($"Redownload##{pluginInfo.Name}"))
+                    {
+                        _ = DownloadReleaseAsync(releaseUrl, pluginInfo.Name);
+                    }
+
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip("Download the latest release archive from the saved URL and replace the plugin files.");
+                    }
+
+                    ImGui.SameLine();
+                }
+                else
+                {
+                    ImGui.TextDisabled("No release URL saved");
+                    ImGui.SameLine();
+                }
+            }
+            else if (!string.IsNullOrEmpty(pluginInfo.CurrentCommit))
             {
                 bool isUpdating = _updatingPlugins.TryGetValue(pluginInfo.Name, out bool updating) && updating;
                 bool isReverting = _revertingPlugins.TryGetValue(pluginInfo.Name, out bool reverting) && reverting;
@@ -610,24 +627,26 @@ namespace PluginUpdater
                     ImGui.BeginDisabled(isReverting || isUpdating);
                     if (pluginInfo.AheadBy == 0 || pluginInfo.BehindBy != 0)
                     {
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0, 0.5f, 0, 1.0f)))
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(0, 0.7f, 0, 1.0f)))
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0, 0.3f, 0, 1.0f)))
-                            if (ImGui.Button(isUpdating ? $"Updating...##{pluginInfo.Name}" : $"Update##{pluginInfo.Name}"))
-                            {
-                                _ = UpdatePluginAsync(pluginInfo.Name, false);
-                            }
+                        ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0, 0.5f, 0, 1.0f));
+                        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(0, 0.7f, 0, 1.0f));
+                        ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0, 0.3f, 0, 1.0f));
+                        if (ImGui.Button(isUpdating ? $"Updating...##{pluginInfo.Name}" : $"Update##{pluginInfo.Name}"))
+                        {
+                            _ = UpdatePluginAsync(pluginInfo.Name, false);
+                        }
 
+                        ImGui.PopStyleColor(3);
                         ImGui.SameLine();
                     }
 
-                    using (ImGuiHelpers.UseStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f)))
-                    using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f)))
-                    using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f)))
-                        if (ImGui.Button(isUpdating ? $"Updating...##{pluginInfo.Name}" : $"Force update##{pluginInfo.Name}"))
-                        {
-                            ImGui.OpenPopup($"Force update plugin {pluginInfo.Name}");
-                        }
+                    ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f));
+                    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f));
+                    ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f));
+                    if (ImGui.Button(isUpdating ? $"Updating...##{pluginInfo.Name}" : $"Force update##{pluginInfo.Name}"))
+                    {
+                        ImGui.OpenPopup($"Force update plugin {pluginInfo.Name}");
+                    }
+                    ImGui.PopStyleColor(3);
 
                     if (ImGui.BeginPopupModal($"Force update plugin {pluginInfo.Name}"))
                     {
@@ -639,15 +658,17 @@ namespace PluginUpdater
                         float totalWidth = buttonWidth * 2 + spacing;
                         ImGui.SetCursorPosX((ImGui.GetWindowSize().X - totalWidth) * 0.5f);
 
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f)))
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f)))
-                        using (ImGuiHelpers.UseStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f)))
+                        ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f));
+                        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f));
+                        ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f));
 
-                            if (ImGui.Button("Force update", new System.Numerics.Vector2(buttonWidth, 0)))
-                            {
-                                ImGui.CloseCurrentPopup();
-                                _ = UpdatePluginAsync(pluginInfo.Name, true);
-                            }
+                        if (ImGui.Button("Force update", new System.Numerics.Vector2(buttonWidth, 0)))
+                        {
+                            ImGui.CloseCurrentPopup();
+                            _ = UpdatePluginAsync(pluginInfo.Name, true);
+                        }
+
+                        ImGui.PopStyleColor(3);
 
                         ImGui.SameLine(0, spacing);
                         if (ImGui.Button("Cancel", new System.Numerics.Vector2(buttonWidth, 0)))
@@ -684,14 +705,21 @@ namespace PluginUpdater
                 Process.Start("explorer.exe", pluginInfo.Path);
             }
 
+            ImGui.SameLine();
+            if (ImGui.Button($"Delete##{pluginInfo.Name}"))
+            {
+                _pluginToDelete = pluginInfo.Name;
+                ImGui.OpenPopup("Delete Plugin?");
+            }
+
             ImGui.TableNextColumn();
         }
 
         private void RenderAddPluginSection()
         {
-            ImGui.Text("Enter Repository URL:");
+            ImGui.Text("Enter Plugin Source URL:");
 
-            var width = ImGui.GetContentRegionAvail().X - 100;
+            var width = Math.Max(150f, ImGui.GetContentRegionAvail().X - 220f);
             ImGui.SetNextItemWidth(width);
             ImGui.InputText("##repoinput", ref _repoUrl, 1024);
 
@@ -700,14 +728,21 @@ namespace PluginUpdater
             if (_isCloning)
             {
                 ImGui.BeginDisabled();
-                ImGui.Button("Cloning...");
+                ImGui.Button("Cloning Git...");
                 ImGui.EndDisabled();
             }
-            else if (ImGui.Button("Clone"))
+            else if (ImGui.Button("Clone Git"))
             {
                 if (!string.IsNullOrWhiteSpace(_repoUrl))
                 {
-                    _ = CloneRepositoryAsync(_repoUrl);
+                    if (TryParseGitHubReleaseUrl(_repoUrl, out _))
+                    {
+                        _consoleLog.LogWarning("This appears to be a GitHub release link. Use the Download Release button instead.");
+                    }
+                    else
+                    {
+                        _ = CloneRepositoryAsync(_repoUrl);
+                    }
                 }
                 else
                 {
@@ -720,9 +755,34 @@ namespace PluginUpdater
                 ImGui.SetTooltip("Clone the repository into the plugins folder");
             }
 
+            ImGui.SameLine();
+
+            if (_isDownloadingRelease)
+            {
+                ImGui.BeginDisabled();
+                ImGui.Button("Downloading release...");
+                ImGui.EndDisabled();
+            }
+            else if (ImGui.Button("Download Release"))
+            {
+                if (!string.IsNullOrWhiteSpace(_repoUrl))
+                {
+                    _ = DownloadReleaseAsync(_repoUrl);
+                }
+                else
+                {
+                    _consoleLog.LogWarning("Please enter a release URL");
+                }
+            }
+
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Download the latest release archive from GitHub and extract it into the plugins folder");
+            }
+
             ImGui.Spacing();
-            ImGui.TextWrapped("Enter the URL of a Git repository to clone. " +
-                              "The repository will be cloned into the Plugins\\Source folder.");
+            ImGui.TextWrapped("Provide a Git repository URL or a GitHub release link (including direct .zip asset URLs). " +
+                              "Release archives are automatically extracted into the Plugins folder.");
         }
 
         private async Task CloneRepositoryAsync(string repoUrl)
@@ -749,278 +809,396 @@ namespace PluginUpdater
             }
         }
 
-        private static readonly System.Text.Json.JsonSerializerOptions SerializerOptions = new()
+        private async Task DownloadReleaseAsync(string releaseUrl, string existingPluginName = null)
         {
-            PropertyNameCaseInsensitive = true,
-        };
+            if (string.IsNullOrWhiteSpace(releaseUrl))
+            {
+                _consoleLog.LogWarning("Please enter a release URL");
+                return;
+            }
 
-        private async Task LoadRepositoriesAsync()
-        {
-            if (_isLoadingRepos || _hasLoadedRepos) return;
+            bool isReinstall = !string.IsNullOrWhiteSpace(existingPluginName);
+
+            if (isReinstall)
+            {
+                if (_releaseReinstalling.TryGetValue(existingPluginName, out bool running) && running)
+                {
+                    return;
+                }
+
+                _releaseReinstalling[existingPluginName] = true;
+            }
+            else
+            {
+                if (_isDownloadingRelease)
+                {
+                    return;
+                }
+
+                _isDownloadingRelease = true;
+            }
+
+            string tempZip = Path.Combine(Path.GetTempPath(), $"PluginUpdater_{Guid.NewGuid():N}.zip");
+            string tempDirectory = Path.Combine(Path.GetTempPath(), $"PluginUpdater_{Guid.NewGuid():N}");
 
             try
             {
-                _isLoadingRepos = true;
-                _loadError = string.Empty;
+                Directory.CreateDirectory(tempDirectory);
 
-                using var client = new System.Net.Http.HttpClient();
-                var response = await client.GetStringAsync("https://raw.githubusercontent.com/exCore2/PluginBrowserData/refs/heads/data/output.json");
+                var releaseInfo = await ResolveReleaseAsync(releaseUrl);
 
-                var repoData = System.Text.Json.JsonSerializer.Deserialize<PluginRepositoryData>(
-                    response,
-                    SerializerOptions
-                );
+                _consoleLog.LogInfo($"Downloading release from {releaseInfo.NormalizedUrl}...");
 
-                _availablePlugins.Clear();
-                if (repoData?.PluginDescriptions != null)
+                await DownloadFileAsync(releaseInfo.DownloadUrl, tempZip);
+
+                ZipFile.ExtractToDirectory(tempZip, tempDirectory, true);
+
+                var (sourceDirectory, pluginName) = DetermineExtractionRoot(tempDirectory, existingPluginName, releaseInfo.PluginNameFallback);
+                pluginName = SanitizePluginName(pluginName);
+
+                var targetDirectory = Path.Combine(_pluginRootPath, pluginName);
+
+                if (Directory.Exists(targetDirectory))
                 {
-                    _availablePlugins.AddRange(repoData.PluginDescriptions);
-                }
-
-                _hasLoadedRepos = true;
-                _consoleLog.LogSuccess($"Successfully loaded {_availablePlugins.Count} plugins");
-            }
-            catch (Exception ex)
-            {
-                _loadError = $"Error loading plugins: {ex.Message}";
-                _consoleLog.LogError(_loadError);
-            }
-            finally
-            {
-                _isLoadingRepos = false;
-            }
-        }
-
-        private string _pluginToDelete = null;
-
-        private void RenderPluginBrowser()
-        {
-            if (!_hasLoadedRepos && !_isLoadingRepos)
-            {
-                _ = LoadRepositoriesAsync();
-            }
-
-            ImGui.TextWrapped("Browse and download available plugins from the ExileCore2 organization.");
-            ImGui.Spacing();
-
-            if (_isLoadingRepos)
-            {
-                ImGui.TextWrapped("Loading available plugins...");
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(_loadError))
-            {
-                ImGui.PushStyleColor(ImGuiCol.Text, new System.Numerics.Vector4(1.0f, 0.2f, 0.2f, 1.0f));
-                ImGui.TextWrapped(_loadError);
-                ImGui.PopStyleColor();
-
-                if (ImGui.Button("Retry"))
-                {
-                    _hasLoadedRepos = false;
-                    _loadError = string.Empty;
-                    _ = LoadRepositoriesAsync();
-                }
-
-                return;
-            }
-
-            var tableFlags = ImGuiTableFlags.Borders |
-                             ImGuiTableFlags.Resizable |
-                             ImGuiTableFlags.SizingFixedFit |
-                             ImGuiTableFlags.ScrollX |
-                             ImGuiTableFlags.ScrollY |
-                             ImGuiTableFlags.RowBg |
-                             ImGuiTableFlags.Hideable;
-
-            var installedPlugins = _updater.GetPluginInfo();
-
-            if (_availablePlugins.Count == 0)
-            {
-                ImGui.TextColored(new System.Numerics.Vector4(1.0f, 0.2f, 0.2f, 1.0f), "No plugins found in the repository.");
-                return;
-            }
-
-            float rowHeight = Math.Max(
-                ImGui.GetTextLineHeightWithSpacing(),
-                ImGui.GetFrameHeight() + ImGui.GetStyle().FramePadding.Y * 2
-            );
-
-            float totalTableHeight = rowHeight * (_availablePlugins.Count + 1);
-            float panelHeight = ImGui.GetContentRegionAvail().Y;
-            float tableHeight = Math.Min(totalTableHeight, panelHeight * 0.60f);
-
-            if (!ImGui.BeginTable("##browsertable", 6, tableFlags, new System.Numerics.Vector2(-1, tableHeight)))
-                return;
-
-            ImGui.TableSetupColumn("Plugin", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Description", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Original Author", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Endorsed Fork", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Last Updated", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableSetupColumn("Action", ImGuiTableColumnFlags.WidthFixed, 50);
-            ImGui.TableHeadersRow();
-
-            foreach (var plugin in _availablePlugins)
-            {
-                ImGui.TableNextRow();
-
-                ImGui.TableNextColumn();
-                ImGui.Text(plugin.Name);
-
-                ImGui.TableNextColumn();
-                ImGui.TextWrapped(string.IsNullOrEmpty(plugin.Description) ? "-" : plugin.Description);
-
-                ImGui.TableNextColumn();
-                ImGui.Text(string.IsNullOrEmpty(plugin.OriginalAuthor) ? "-" : plugin.OriginalAuthor);
-
-                ImGui.TableNextColumn();
-                ImGui.Text(string.IsNullOrEmpty(plugin.EndorsedAuthor) ? "-" : plugin.EndorsedAuthor);
-
-                var endorsedFork = string.IsNullOrWhiteSpace(plugin.EndorsedAuthor)
-                    ? plugin.Forks?.FirstOrDefault()
-                    : plugin.Forks?.FirstOrDefault(f => f.Author == plugin.EndorsedAuthor);
-
-                ImGui.TableNextColumn();
-                var lastUpdated = endorsedFork?.LatestCommit?.Date ?? "-";
-                if (lastUpdated != "-")
-                {
-                    lastUpdated = DateTime.Parse(lastUpdated).ToString("yyyy-MM-dd");
-                }
-
-                ImGui.Text(lastUpdated);
-
-                ImGui.TableNextColumn();
-
-                if (endorsedFork == null) continue;
-
-                bool isInstalled = installedPlugins.Any(ip =>
-                    ip.Name.Equals(endorsedFork.Name, StringComparison.OrdinalIgnoreCase));
-
-                if (isInstalled)
-                {
-                    ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f));
-                    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f));
-                    ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f));
-
-                    if (ImGui.Button($"Delete##{endorsedFork.Name}"))
-                    {
-                        _pluginToDelete = endorsedFork.Name;
-                        ImGui.OpenPopup("Delete Plugin?");
-                    }
-
-                    if (ImGui.IsItemHovered())
-                    {
-                        ImGui.SetTooltip("Delete this plugin");
-                    }
-
-                    ImGui.PopStyleColor(3);
+                    PluginLifecycleHelper.TryUnloadPlugin(pluginName, _consoleLog);
+                    DeleteDirectory(targetDirectory);
+                    _consoleLog.LogInfo($"Replacing existing plugin {pluginName} with the downloaded release");
                 }
                 else
                 {
-                    bool isDownloading = _downloadingPlugins.TryGetValue(plugin.Name, out bool downloading) && downloading;
-
-                    if (isDownloading)
-                    {
-                        ImGui.BeginDisabled();
-                        ImGui.Button($"Downloading...##{plugin.Name}");
-                        ImGui.EndDisabled();
-                    }
-                    else
-                    {
-                        ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0, 0.5f, 0, 1.0f));
-                        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(0, 0.7f, 0, 1.0f));
-                        ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0, 0.3f, 0, 1.0f));
-
-                        if (ImGui.Button($"Download##{plugin.Name}"))
-                        {
-                            string cloneUrl = $"https://github.com/{endorsedFork.Location}/{endorsedFork.Name}.git";
-                            _ = DownloadPluginAsync(plugin.Name, cloneUrl);
-                        }
-
-                        if (ImGui.IsItemHovered() && !string.IsNullOrEmpty(endorsedFork.LatestCommit?.Message))
-                        {
-                            ImGui.SetTooltip($"Latest commit: {endorsedFork.LatestCommit.Message}");
-                        }
-
-                        ImGui.PopStyleColor(3);
-                    }
+                    _consoleLog.LogInfo($"Installing plugin {pluginName} from release archive");
                 }
-            }
 
-            if (ImGui.BeginPopupModal("Delete Plugin?"))
-            {
-                ImGui.Text($"Are you sure you want to delete the plugin '{_pluginToDelete}'?");
-                ImGui.Text("This action cannot be undone!");
-                ImGui.Spacing();
+                Directory.CreateDirectory(targetDirectory);
+                CopyDirectoryContents(sourceDirectory, targetDirectory);
 
-                float buttonWidth = 120;
-                float spacing = 20;
-                float totalWidth = (buttonWidth * 2) + spacing;
-                ImGui.SetCursorPosX((ImGui.GetWindowSize().X - totalWidth) * 0.5f);
+                _consoleLog.LogSuccess($"Installed release for {pluginName}");
 
-                ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f));
-                ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f));
-                ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f));
-
-                if (ImGui.Button("Delete", new System.Numerics.Vector2(buttonWidth, 0)))
+                if (!isReinstall)
                 {
-                    try
-                    {
-                        _updater.DeletePlugin(_pluginToDelete);
-                        _consoleLog.LogSuccess($"Successfully deleted plugin: {_pluginToDelete}");
-                        ImGui.CloseCurrentPopup();
-                    }
-                    catch (Exception ex)
-                    {
-                        _consoleLog.LogError($"Failed to delete plugin: {ex.Message}");
-                        ImGui.CloseCurrentPopup();
-                    }
+                    _repoUrl = string.Empty;
                 }
 
-                ImGui.PopStyleColor(3);
-
-                ImGui.SameLine(0, spacing);
-                if (ImGui.Button("Cancel", new System.Numerics.Vector2(buttonWidth, 0)))
+                var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                if (releaseSources != null)
                 {
-                    ImGui.CloseCurrentPopup();
+                    releaseSources[pluginName] = releaseInfo.NormalizedUrl;
+                    PluginUpdater.Instance?.SaveSettings();
                 }
 
-                ImGui.EndPopup();
-            }
-
-            ImGui.EndTable();
-        }
-
-        private async Task DownloadPluginAsync(string pluginName, string cloneUrl)
-        {
-            if (_downloadingPlugins.TryGetValue(pluginName, out bool isDownloading) && isDownloading)
-                return;
-
-            try
-            {
-                _downloadingPlugins[pluginName] = true;
-                _consoleLog.LogInfo($"Downloading plugin: {pluginName}");
-
-                await _updater.CloneRepositoryAsync(cloneUrl);
-
-                _consoleLog.LogSuccess($"Successfully downloaded {pluginName}");
+                _updater.UpdateLocal();
             }
             catch (Exception ex)
             {
-                var additionalDetails = ex.Message switch
-                {
-                    var x when x.Contains("unknown certificate lookup failure", StringComparison.OrdinalIgnoreCase) =>
-                        $"This probably means your internet connection to the server the plugin is hosted on ({cloneUrl}) is being disrupted by something",
-                    _ => "",
-                };
-                _consoleLog.LogError($"Error downloading plugin {pluginName}: {ex.Message} {additionalDetails}");
+                _consoleLog.LogError($"Error downloading release: {ex.Message}");
             }
             finally
             {
-                _downloadingPlugins[pluginName] = false;
+                if (File.Exists(tempZip))
+                {
+                    try
+                    {
+                        File.Delete(tempZip);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+
+                if (Directory.Exists(tempDirectory))
+                {
+                    try
+                    {
+                        Directory.Delete(tempDirectory, true);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+
+                if (isReinstall)
+                {
+                    _releaseReinstalling.Remove(existingPluginName);
+                }
+                else
+                {
+                    _isDownloadingRelease = false;
+                }
             }
         }
+
+        private static async Task DownloadFileAsync(string url, string destinationPath)
+        {
+            using var client = CreateHttpClient();
+            using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            await using var fileStream = File.Create(destinationPath);
+            await stream.CopyToAsync(fileStream);
+        }
+
+        private async Task<ReleaseDownloadInfo> ResolveReleaseAsync(string releaseUrl)
+        {
+            if (!TryParseGitHubReleaseUrl(releaseUrl, out var parts))
+            {
+                throw new InvalidOperationException("Only GitHub release URLs are supported");
+            }
+
+            if (parts.IsDirectAsset)
+            {
+                var fallback = Path.GetFileNameWithoutExtension(parts.AssetName);
+                var normalized = string.IsNullOrWhiteSpace(parts.Tag)
+                    ? $"https://github.com/{parts.Owner}/{parts.Repo}/releases"
+                    : $"https://github.com/{parts.Owner}/{parts.Repo}/releases/tag/{parts.Tag}";
+
+                return new ReleaseDownloadInfo(releaseUrl, fallback, normalized);
+            }
+
+            var apiSuffix = !string.IsNullOrWhiteSpace(parts.Tag)
+                ? $"tags/{parts.Tag}"
+                : "latest";
+
+            var apiUrl = $"https://api.github.com/repos/{parts.Owner}/{parts.Repo}/releases/{apiSuffix}";
+
+            using var client = CreateHttpClient();
+            using var response = await client.GetAsync(apiUrl);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            using var document = await JsonDocument.ParseAsync(stream);
+
+            var root = document.RootElement;
+
+            string tagName = null;
+            if (root.TryGetProperty("tag_name", out var tagProperty))
+            {
+                tagName = tagProperty.GetString();
+            }
+
+            string downloadUrl = null;
+            string assetName = null;
+
+            if (root.TryGetProperty("assets", out var assets))
+            {
+                foreach (var asset in assets.EnumerateArray())
+                {
+                    var candidateUrl = asset.TryGetProperty("browser_download_url", out var urlProperty)
+                        ? urlProperty.GetString()
+                        : null;
+
+                    if (string.IsNullOrWhiteSpace(candidateUrl) ||
+                        !candidateUrl.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    downloadUrl = candidateUrl;
+                    assetName = asset.TryGetProperty("name", out var nameProperty) ? nameProperty.GetString() : null;
+                    break;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(downloadUrl))
+            {
+                throw new InvalidOperationException("No .zip assets found for the specified release");
+            }
+
+            var fallbackName = !string.IsNullOrWhiteSpace(assetName)
+                ? Path.GetFileNameWithoutExtension(assetName)
+                : parts.Repo;
+
+            var normalizedUrl = !string.IsNullOrWhiteSpace(tagName)
+                ? $"https://github.com/{parts.Owner}/{parts.Repo}/releases/tag/{tagName}"
+                : $"https://github.com/{parts.Owner}/{parts.Repo}/releases";
+
+            return new ReleaseDownloadInfo(downloadUrl, fallbackName, normalizedUrl);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PluginUpdater", "1.0"));
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+            return client;
+        }
+
+        private static bool TryParseGitHubReleaseUrl(string releaseUrl, out ReleaseUrlParts parts)
+        {
+            parts = null;
+
+            if (!Uri.TryCreate(releaseUrl, UriKind.Absolute, out var uri))
+            {
+                return false;
+            }
+
+            if (!uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 3)
+            {
+                return false;
+            }
+
+            if (!segments[2].Equals("releases", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var owner = segments[0];
+            var repo = segments[1];
+            string tag = null;
+            bool isDirectAsset = false;
+            string assetName = null;
+
+            if (segments.Length >= 4)
+            {
+                var segment = segments[3];
+                if (segment.Equals("tag", StringComparison.OrdinalIgnoreCase) && segments.Length >= 5)
+                {
+                    tag = segments[4];
+                }
+                else if (segment.Equals("download", StringComparison.OrdinalIgnoreCase) && segments.Length >= 6)
+                {
+                    isDirectAsset = true;
+                    tag = segments[4];
+                    assetName = segments[5];
+                }
+            }
+
+            parts = new ReleaseUrlParts(owner, repo, tag, isDirectAsset, assetName);
+            return true;
+        }
+
+        private static (string SourceDirectory, string PluginName) DetermineExtractionRoot(string extractedRoot, string existingPluginName, string fallbackName)
+        {
+            if (!string.IsNullOrWhiteSpace(existingPluginName))
+            {
+                return (extractedRoot, existingPluginName);
+            }
+
+            var directories = Directory.GetDirectories(extractedRoot);
+            var files = Directory.GetFiles(extractedRoot);
+
+            if (directories.Length == 1 && files.Length == 0)
+            {
+                var directory = directories[0];
+                var name = Path.GetFileName(directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                return (directory, string.IsNullOrWhiteSpace(name) ? fallbackName : name);
+            }
+
+            return (extractedRoot, fallbackName);
+        }
+
+        private static void CopyDirectoryContents(string sourceDirectory, string targetDirectory)
+        {
+            foreach (var directory in Directory.GetDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(sourceDirectory, directory);
+                Directory.CreateDirectory(Path.Combine(targetDirectory, relative));
+            }
+
+            foreach (var file in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(sourceDirectory, file);
+                var destination = Path.Combine(targetDirectory, relative);
+                Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+                File.Copy(file, destination, true);
+            }
+        }
+
+        private static void DeleteDirectory(string directory)
+        {
+            foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+
+            foreach (var dir in Directory.GetDirectories(directory, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(dir, FileAttributes.Normal);
+            }
+
+            Directory.Delete(directory, true);
+        }
+
+        private static string SanitizePluginName(string pluginName)
+        {
+            if (string.IsNullOrWhiteSpace(pluginName))
+            {
+                return $"Plugin_{Guid.NewGuid():N}";
+            }
+
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var sanitized = new string(pluginName.Select(ch => invalidChars.Contains(ch) ? '_' : ch).ToArray());
+
+            return string.IsNullOrWhiteSpace(sanitized) ? $"Plugin_{Guid.NewGuid():N}" : sanitized;
+        }
+
+        private void RenderDeleteConfirmationModal()
+        {
+            if (!ImGui.BeginPopupModal("Delete Plugin?", ImGuiWindowFlags.AlwaysAutoResize))
+            {
+                return;
+            }
+
+            ImGui.Text($"Are you sure you want to delete the plugin '{_pluginToDelete}'?");
+            ImGui.Text("This action cannot be undone!");
+            ImGui.Spacing();
+
+            float buttonWidth = 120f;
+            float spacing = 20f;
+            float totalWidth = (buttonWidth * 2f) + spacing;
+            ImGui.SetCursorPosX((ImGui.GetWindowSize().X - totalWidth) * 0.5f);
+
+            ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0.8f, 0.2f, 0.2f, 1.0f));
+            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(1.0f, 0.3f, 0.3f, 1.0f));
+            ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0.6f, 0.1f, 0.1f, 1.0f));
+
+            if (ImGui.Button("Delete", new System.Numerics.Vector2(buttonWidth, 0)))
+            {
+                try
+                {
+                    _updater.DeletePlugin(_pluginToDelete);
+                    _consoleLog.LogSuccess($"Successfully deleted plugin: {_pluginToDelete}");
+
+                    var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                    if (releaseSources != null && releaseSources.Remove(_pluginToDelete))
+                    {
+                        PluginUpdater.Instance?.SaveSettings();
+                    }
+
+                    _updater.UpdateLocal();
+                }
+                catch (Exception ex)
+                {
+                    _consoleLog.LogError($"Failed to delete plugin: {ex.Message}");
+                }
+                finally
+                {
+                    _pluginToDelete = null;
+                    ImGui.CloseCurrentPopup();
+                }
+            }
+
+            ImGui.PopStyleColor(3);
+
+            ImGui.SameLine(0, spacing);
+            if (ImGui.Button("Cancel", new System.Numerics.Vector2(buttonWidth, 0)))
+            {
+                _pluginToDelete = null;
+                ImGui.CloseCurrentPopup();
+            }
+
+            ImGui.EndPopup();
+        }
+
+
 
 
         public void Dispose()

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -50,6 +50,8 @@ namespace PluginUpdater
 
         public void Startup()
         {
+            CleanupPendingDirectories();
+
             _updater = new GitUpdater(_pluginRootPath);
             _updater.ProgressChanged += (current, total) =>
             {
@@ -1019,16 +1021,31 @@ namespace PluginUpdater
 
                 ZipFile.ExtractToDirectory(tempZip, tempDirectory, true);
 
-                var (sourceDirectory, pluginName) = DetermineExtractionRoot(tempDirectory, existingPluginName, releaseInfo.PluginNameFallback);
-                pluginName = SanitizePluginName(pluginName);
+                var (sourceDirectory, extractedName) = DetermineExtractionRoot(tempDirectory, existingPluginName, releaseInfo.PluginNameFallback);
+                var pluginName = SanitizePluginName(extractedName);
 
-                var targetDirectory = Path.Combine(_pluginRootPath, pluginName);
+                var installDirectories = PluginUpdater.Instance?.Settings.ReleaseInstallDirectories;
+                var targetDirectoryName = ResolveTargetDirectoryName(pluginName, installDirectories);
+                var targetDirectory = Path.Combine(_pluginRootPath, targetDirectoryName);
+                var reusedExistingDirectory = false;
 
                 if (Directory.Exists(targetDirectory))
                 {
                     PluginLifecycleHelper.TryUnloadPlugin(pluginName, _consoleLog);
-                    DeleteDirectory(targetDirectory);
-                    _consoleLog.LogInfo($"Replacing existing plugin {pluginName} with the downloaded release");
+
+                    if (!TryDeleteDirectory(targetDirectory, out var failure))
+                    {
+                        _consoleLog.LogWarning($"Could not replace existing plugin files for {pluginName}: {failure.Message}. Installing into a new folder instead.");
+                        ScheduleDirectoryForCleanup(targetDirectory);
+                        targetDirectoryName = GenerateUniqueDirectoryName(pluginName);
+                        targetDirectory = Path.Combine(_pluginRootPath, targetDirectoryName);
+                    }
+                    else
+                    {
+                        reusedExistingDirectory = true;
+                        ClearPendingCleanupEntry(targetDirectory);
+                        _consoleLog.LogInfo($"Replacing existing plugin {pluginName} with the downloaded release");
+                    }
                 }
                 else
                 {
@@ -1066,6 +1083,16 @@ namespace PluginUpdater
                 {
                     releaseChecksums[pluginName] = releaseChecksum;
                     settingsChanged = true;
+                }
+
+                if (installDirectories != null)
+                {
+                    if (!installDirectories.TryGetValue(pluginName, out var recordedName) ||
+                        !string.Equals(recordedName, targetDirectoryName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        installDirectories[pluginName] = targetDirectoryName;
+                        settingsChanged = true;
+                    }
                 }
 
                 if (settingsChanged)
@@ -1346,8 +1373,15 @@ namespace PluginUpdater
             }
         }
 
-        private static void DeleteDirectory(string directory)
+        private static bool TryDeleteDirectory(string directory, out Exception failure)
         {
+            failure = null;
+
+            if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+            {
+                return true;
+            }
+
             const int maxAttempts = 5;
 
             for (int attempt = 0; attempt < maxAttempts; attempt++)
@@ -1356,18 +1390,29 @@ namespace PluginUpdater
                 {
                     NormalizeDirectoryAttributes(directory);
                     Directory.Delete(directory, true);
-                    return;
+                    return true;
                 }
-                catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < maxAttempts - 1)
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {
+                    failure = ex;
                     PluginLogger.Warn($"Failed to delete {directory} on attempt {attempt + 1}: {ex.Message}. Retrying after releasing file handles.");
                     PluginLifecycleHelper.EnsureAssembliesReleased();
                     Thread.Sleep(200);
                 }
             }
 
-            NormalizeDirectoryAttributes(directory);
-            Directory.Delete(directory, true);
+            try
+            {
+                NormalizeDirectoryAttributes(directory);
+                Directory.Delete(directory, true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+                PluginLogger.Warn($"Final attempt to delete {directory} failed: {ex.Message}");
+                return false;
+            }
         }
 
         private static void NormalizeDirectoryAttributes(string directory)
@@ -1401,6 +1446,138 @@ namespace PluginUpdater
             return string.IsNullOrWhiteSpace(sanitized) ? $"Plugin_{Guid.NewGuid():N}" : sanitized;
         }
 
+        private string ResolveTargetDirectoryName(string pluginName, Dictionary<string, string> installDirectories)
+        {
+            if (installDirectories != null &&
+                installDirectories.TryGetValue(pluginName, out var directoryName) &&
+                !string.IsNullOrWhiteSpace(directoryName))
+            {
+                return directoryName;
+            }
+
+            return SanitizePluginName(pluginName);
+        }
+
+        private static string GenerateUniqueDirectoryName(string pluginName)
+        {
+            var sanitized = SanitizePluginName(pluginName);
+            return $"{sanitized}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+        }
+
+        private void ScheduleDirectoryForCleanup(string directory)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                var dirInfo = new DirectoryInfo(directory);
+                dirInfo.Attributes |= FileAttributes.Hidden;
+
+                var pending = PluginUpdater.Instance?.Settings.PendingDeletionDirectories;
+                if (pending == null)
+                {
+                    return;
+                }
+
+                var relative = GetRelativePluginPath(directory);
+                if (pending.Any(entry => string.Equals(entry, relative, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
+                pending.Add(relative);
+                PluginUpdater.Instance?.SaveSettings();
+            }
+            catch (Exception ex)
+            {
+                PluginLogger.Warn($"Failed to schedule cleanup for {directory}: {ex.Message}");
+            }
+        }
+
+        private void ClearPendingCleanupEntry(string directory)
+        {
+            try
+            {
+                var pending = PluginUpdater.Instance?.Settings.PendingDeletionDirectories;
+                if (pending == null || pending.Count == 0)
+                {
+                    return;
+                }
+
+                var relative = GetRelativePluginPath(directory);
+                var removed = pending.RemoveAll(entry => string.Equals(entry, relative, StringComparison.OrdinalIgnoreCase));
+
+                if (removed > 0)
+                {
+                    PluginUpdater.Instance?.SaveSettings();
+                }
+            }
+            catch (Exception ex)
+            {
+                PluginLogger.Warn($"Failed to clear pending cleanup entry for {directory}: {ex.Message}");
+            }
+        }
+
+        private void CleanupPendingDirectories()
+        {
+            var pending = PluginUpdater.Instance?.Settings.PendingDeletionDirectories;
+            if (pending == null || pending.Count == 0)
+            {
+                return;
+            }
+
+            var directories = pending.ToList();
+            var removedAny = false;
+
+            foreach (var entry in directories)
+            {
+                var fullPath = Path.IsPathRooted(entry) ? entry : Path.Combine(_pluginRootPath, entry);
+
+                if (!Directory.Exists(fullPath))
+                {
+                    pending.Remove(entry);
+                    removedAny = true;
+                    continue;
+                }
+
+                if (TryDeleteDirectory(fullPath, out var failure))
+                {
+                    pending.Remove(entry);
+                    removedAny = true;
+                }
+                else if (failure != null)
+                {
+                    PluginLogger.Warn($"Deferred cleanup for {fullPath} failed: {failure.Message}");
+                }
+            }
+
+            if (removedAny)
+            {
+                PluginUpdater.Instance?.SaveSettings();
+            }
+        }
+
+        private string GetRelativePluginPath(string directory)
+        {
+            try
+            {
+                var relative = Path.GetRelativePath(_pluginRootPath, directory);
+                if (!relative.StartsWith("..", StringComparison.Ordinal))
+                {
+                    return relative;
+                }
+            }
+            catch
+            {
+                // fall back to absolute path
+            }
+
+            return directory;
+        }
+
         private void RenderDeleteConfirmationModal()
         {
             if (!ImGui.BeginPopupModal("Delete Plugin?"))
@@ -1430,6 +1607,7 @@ namespace PluginUpdater
 
                     var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
                     var releaseChecksums = PluginUpdater.Instance?.Settings.ReleaseChecksums;
+                    var installDirectories = PluginUpdater.Instance?.Settings.ReleaseInstallDirectories;
                     bool settingsChanged = false;
 
                     if (releaseSources != null && releaseSources.Remove(_pluginToDelete))
@@ -1440,6 +1618,14 @@ namespace PluginUpdater
                     if (releaseChecksums != null && releaseChecksums.Remove(_pluginToDelete))
                     {
                         settingsChanged = true;
+                    }
+
+                    if (installDirectories != null && installDirectories.TryGetValue(_pluginToDelete, out var directoryName))
+                    {
+                        installDirectories.Remove(_pluginToDelete);
+                        settingsChanged = true;
+                        var fullPath = Path.Combine(_pluginRootPath, directoryName);
+                        ClearPendingCleanupEntry(fullPath);
                     }
 
                     if (settingsChanged)

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -1036,7 +1036,14 @@ namespace PluginUpdater
                 Directory.CreateDirectory(targetDirectory);
                 CopyDirectoryContents(sourceDirectory, targetDirectory);
 
-                _consoleLog.LogSuccess($"Installed release for {pluginName}");
+                if (!PluginLifecycleHelper.TryLoadPlugin(pluginName, targetDirectory, _consoleLog))
+                {
+                    _consoleLog.LogWarning($"Installed plugin {pluginName} but could not load it automatically. Enable it from settings if needed.");
+                }
+                else
+                {
+                    _consoleLog.LogSuccess($"Installed release for {pluginName}");
+                }
 
                 if (!isReinstall)
                 {

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -1403,7 +1403,7 @@ namespace PluginUpdater
 
         private void RenderDeleteConfirmationModal()
         {
-            if (!ImGui.BeginPopupModal("Delete Plugin?", ImGuiWindowFlags.AlwaysAutoResize))
+            if (!ImGui.BeginPopupModal("Delete Plugin?"))
             {
                 return;
             }

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using ImGuiNET;
@@ -29,6 +30,10 @@ namespace PluginUpdater
         private bool _isCloning;
         private bool _isDownloadingRelease;
         private readonly Dictionary<string, bool> _releaseReinstalling = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _latestReleaseChecksums = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _releaseUpdatesAvailable = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _missingChecksumLogged = new(StringComparer.OrdinalIgnoreCase);
+        private bool _isCheckingReleaseUpdates;
         private DateTime _lastPeriodicCheckAttempt = DateTime.MinValue;
         private string _pluginToDelete;
 
@@ -80,6 +85,107 @@ namespace PluginUpdater
             }
         }
 
+        private async Task CheckReleaseUpdatesAsync()
+        {
+            if (_isCheckingReleaseUpdates)
+            {
+                return;
+            }
+
+            var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+            if (releaseSources == null || releaseSources.Count == 0)
+            {
+                _releaseUpdatesAvailable.Clear();
+                _latestReleaseChecksums.Clear();
+                _missingChecksumLogged.Clear();
+                return;
+            }
+
+            _isCheckingReleaseUpdates = true;
+
+            try
+            {
+                var releaseChecksums = PluginUpdater.Instance?.Settings.ReleaseChecksums;
+
+                var trackedPlugins = new HashSet<string>(releaseSources.Keys, StringComparer.OrdinalIgnoreCase);
+                _releaseUpdatesAvailable.RemoveWhere(name => !trackedPlugins.Contains(name));
+
+                foreach (var key in _latestReleaseChecksums.Keys.Where(key => !trackedPlugins.Contains(key)).ToList())
+                {
+                    _latestReleaseChecksums.Remove(key);
+                }
+
+                _missingChecksumLogged.RemoveWhere(name => !trackedPlugins.Contains(name));
+
+                int processed = 0;
+                _totalProgress = releaseSources.Count;
+                _currentProgress = 0;
+
+                foreach (var kvp in releaseSources.ToArray())
+                {
+                    var pluginName = kvp.Key;
+                    var releaseUrl = kvp.Value;
+
+                    if (string.IsNullOrWhiteSpace(releaseUrl))
+                    {
+                        _currentProgress = ++processed;
+                        continue;
+                    }
+
+                    if (_releaseReinstalling.TryGetValue(pluginName, out bool reinstalling) && reinstalling)
+                    {
+                        _currentProgress = ++processed;
+                        continue;
+                    }
+
+                    try
+                    {
+                        var releaseInfo = await ResolveReleaseAsync(releaseUrl);
+                        var checksum = await DownloadReleaseChecksumAsync(releaseInfo.DownloadUrl);
+                        _latestReleaseChecksums[pluginName] = checksum;
+
+                        if (releaseChecksums != null &&
+                            releaseChecksums.TryGetValue(pluginName, out var storedChecksum) &&
+                            !string.IsNullOrWhiteSpace(storedChecksum))
+                        {
+                            if (string.Equals(storedChecksum, checksum, StringComparison.OrdinalIgnoreCase))
+                            {
+                                _releaseUpdatesAvailable.Remove(pluginName);
+                            }
+                            else
+                            {
+                                _releaseUpdatesAvailable.Add(pluginName);
+                            }
+                        }
+                        else
+                        {
+                            if (_missingChecksumLogged.Add(pluginName))
+                            {
+                                _consoleLog.LogWarning($"No checksum recorded for {pluginName}. Redownload to start release tracking.");
+                            }
+
+                            _releaseUpdatesAvailable.Add(pluginName);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        PluginLogger.Warn($"Failed to check release for {pluginName}: {ex.Message}");
+                        _consoleLog.LogWarning($"Failed to check release for {pluginName}: {ex.Message}");
+                    }
+                    finally
+                    {
+                        _currentProgress = ++processed;
+                    }
+                }
+            }
+            finally
+            {
+                _isCheckingReleaseUpdates = false;
+                _currentProgress = 0;
+                _totalProgress = 0;
+            }
+        }
+
         private async Task UpdateGitInfoAsync()
         {
             if (_isUpdating) return;
@@ -88,6 +194,7 @@ namespace PluginUpdater
             {
                 _isUpdating = true;
                 await _updater.UpdateGitInfoAsync();
+                await CheckReleaseUpdatesAsync();
 
                 var plugins = _updater.GetPluginInfo();
                 int updateCount = plugins.Count(p => p.CurrentCommit != p.LatestCommit);
@@ -95,6 +202,12 @@ namespace PluginUpdater
                 {
                     var updateLabel = updateCount == 1 ? "update" : "updates";
                     _consoleLog.LogInfo($"There {(updateCount == 1 ? "is" : "are")} {updateCount} plugin {updateLabel} pending.");
+                }
+
+                if (_releaseUpdatesAvailable.Count > 0)
+                {
+                    var releaseLabel = _releaseUpdatesAvailable.Count == 1 ? "release update" : "release updates";
+                    _consoleLog.LogInfo($"There {(_releaseUpdatesAvailable.Count == 1 ? "is" : "are")} {_releaseUpdatesAvailable.Count} {releaseLabel} available.");
                 }
             }
             catch (Exception e)
@@ -357,6 +470,15 @@ namespace PluginUpdater
 
             ImGui.InputTextWithHint("##filter", "Filter", ref _pluginNameFilter, 200);
 
+            if (_releaseUpdatesAvailable.Count > 0)
+            {
+                ImGui.SameLine();
+                var releaseText = _releaseUpdatesAvailable.Count == 1
+                    ? "1 release update available"
+                    : $"{_releaseUpdatesAvailable.Count} release updates available";
+                ImGui.TextColored(new System.Numerics.Vector4(1f, 0.8f, 0.2f, 1f), releaseText);
+            }
+
             if(_isUpdating && _totalProgress > 0)
             {
                 float progress = (float)_currentProgress / _totalProgress;
@@ -510,6 +632,7 @@ namespace PluginUpdater
             if (pluginInfo.IsManualInstall)
             {
                 var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                var releaseChecksums = PluginUpdater.Instance?.Settings.ReleaseChecksums;
                 if (releaseSources != null && releaseSources.TryGetValue(pluginInfo.Name, out var source))
                 {
                     ImGui.TextWrapped($"Installed from release: {source}");
@@ -517,6 +640,27 @@ namespace PluginUpdater
                 else
                 {
                     ImGui.TextWrapped("Installed from release archive. Use the Add tab to redownload when updates are available.");
+                }
+
+                if (_releaseUpdatesAvailable.Contains(pluginInfo.Name))
+                {
+                    ImGui.PushStyleColor(ImGuiCol.Text, new System.Numerics.Vector4(1f, 0.6f, 0f, 1f));
+                    ImGui.TextWrapped("New release available. Use Redownload to install the latest files.");
+                    ImGui.PopStyleColor();
+
+                    if (releaseChecksums != null && releaseChecksums.TryGetValue(pluginInfo.Name, out var storedChecksum) && !string.IsNullOrWhiteSpace(storedChecksum))
+                    {
+                        ImGui.Text($"Installed checksum: {ShortenHash(storedChecksum)}");
+                    }
+
+                    if (_latestReleaseChecksums.TryGetValue(pluginInfo.Name, out var latestChecksum))
+                    {
+                        ImGui.Text($"Latest checksum: {ShortenHash(latestChecksum)}");
+                    }
+                }
+                else if (releaseChecksums != null && releaseChecksums.TryGetValue(pluginInfo.Name, out var installedChecksum) && !string.IsNullOrWhiteSpace(installedChecksum))
+                {
+                    ImGui.Text($"Installed checksum: {ShortenHash(installedChecksum)}");
                 }
 
                 ImGui.TableNextColumn();
@@ -599,9 +743,28 @@ namespace PluginUpdater
                         ImGui.Button($"Redownloading...##{pluginInfo.Name}");
                         ImGui.EndDisabled();
                     }
-                    else if (ImGui.Button($"Redownload##{pluginInfo.Name}"))
+                    else
                     {
-                        _ = DownloadReleaseAsync(releaseUrl, pluginInfo.Name);
+                        bool hasUpdate = _releaseUpdatesAvailable.Contains(pluginInfo.Name);
+
+                        if (hasUpdate)
+                        {
+                            ImGui.PushStyleColor(ImGuiCol.Button, new System.Numerics.Vector4(0f, 0.5f, 0f, 1.0f));
+                            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, new System.Numerics.Vector4(0f, 0.7f, 0f, 1.0f));
+                            ImGui.PushStyleColor(ImGuiCol.ButtonActive, new System.Numerics.Vector4(0f, 0.3f, 0f, 1.0f));
+                        }
+
+                        var buttonLabel = hasUpdate ? $"Update##{pluginInfo.Name}" : $"Redownload##{pluginInfo.Name}";
+
+                        if (ImGui.Button(buttonLabel))
+                        {
+                            _ = DownloadReleaseAsync(releaseUrl, pluginInfo.Name);
+                        }
+
+                        if (hasUpdate)
+                        {
+                            ImGui.PopStyleColor(3);
+                        }
                     }
 
                     if (ImGui.IsItemHovered())
@@ -850,6 +1013,7 @@ namespace PluginUpdater
                 _consoleLog.LogInfo($"Downloading release from {releaseInfo.NormalizedUrl}...");
 
                 await DownloadFileAsync(releaseInfo.DownloadUrl, tempZip);
+                var releaseChecksum = ComputeFileChecksum(tempZip);
 
                 ZipFile.ExtractToDirectory(tempZip, tempDirectory, true);
 
@@ -880,11 +1044,29 @@ namespace PluginUpdater
                 }
 
                 var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                var releaseChecksums = PluginUpdater.Instance?.Settings.ReleaseChecksums;
+                bool settingsChanged = false;
+
                 if (releaseSources != null)
                 {
                     releaseSources[pluginName] = releaseInfo.NormalizedUrl;
+                    settingsChanged = true;
+                }
+
+                if (releaseChecksums != null)
+                {
+                    releaseChecksums[pluginName] = releaseChecksum;
+                    settingsChanged = true;
+                }
+
+                if (settingsChanged)
+                {
                     PluginUpdater.Instance?.SaveSettings();
                 }
+
+                _latestReleaseChecksums[pluginName] = releaseChecksum;
+                _releaseUpdatesAvailable.Remove(pluginName);
+                _missingChecksumLogged.Remove(pluginName);
 
                 _updater.UpdateLocal();
             }
@@ -929,6 +1111,31 @@ namespace PluginUpdater
             }
         }
 
+        private static async Task<string> DownloadReleaseChecksumAsync(string downloadUrl)
+        {
+            string tempFile = Path.Combine(Path.GetTempPath(), $"PluginUpdater_checksum_{Guid.NewGuid():N}.zip");
+
+            try
+            {
+                await DownloadFileAsync(downloadUrl, tempFile);
+                return ComputeFileChecksum(tempFile);
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                {
+                    try
+                    {
+                        File.Delete(tempFile);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+            }
+        }
+
         private static async Task DownloadFileAsync(string url, string destinationPath)
         {
             using var client = CreateHttpClient();
@@ -938,6 +1145,24 @@ namespace PluginUpdater
             await using var stream = await response.Content.ReadAsStreamAsync();
             await using var fileStream = File.Create(destinationPath);
             await stream.CopyToAsync(fileStream);
+        }
+
+        private static string ComputeFileChecksum(string filePath)
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(stream);
+            return Convert.ToHexString(hash);
+        }
+
+        private static string ShortenHash(string hash)
+        {
+            if (string.IsNullOrWhiteSpace(hash))
+            {
+                return "unknown";
+            }
+
+            return hash.Length > 8 ? hash[..8] : hash;
         }
 
         private async Task<ReleaseDownloadInfo> ResolveReleaseAsync(string releaseUrl)
@@ -1168,10 +1393,27 @@ namespace PluginUpdater
                     _consoleLog.LogSuccess($"Successfully deleted plugin: {_pluginToDelete}");
 
                     var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
+                    var releaseChecksums = PluginUpdater.Instance?.Settings.ReleaseChecksums;
+                    bool settingsChanged = false;
+
                     if (releaseSources != null && releaseSources.Remove(_pluginToDelete))
+                    {
+                        settingsChanged = true;
+                    }
+
+                    if (releaseChecksums != null && releaseChecksums.Remove(_pluginToDelete))
+                    {
+                        settingsChanged = true;
+                    }
+
+                    if (settingsChanged)
                     {
                         PluginUpdater.Instance?.SaveSettings();
                     }
+
+                    _releaseUpdatesAvailable.Remove(_pluginToDelete);
+                    _latestReleaseChecksums.Remove(_pluginToDelete);
+                    _missingChecksumLogged.Remove(_pluginToDelete);
 
                     _updater.UpdateLocal();
                 }

--- a/PluginRenderer.cs
+++ b/PluginRenderer.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using ImGuiNET;
 
@@ -29,10 +30,10 @@ namespace PluginUpdater
         private string _repoUrl = string.Empty;
         private bool _isCloning;
         private bool _isDownloadingRelease;
-        private readonly Dictionary<string, bool> _releaseReinstalling = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, string> _latestReleaseChecksums = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _releaseUpdatesAvailable = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _missingChecksumLogged = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, bool> _releaseReinstalling = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string> _latestReleaseChecksums = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> _releaseUpdatesAvailable = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> _missingChecksumLogged = new(StringComparer.OrdinalIgnoreCase);
         private bool _isCheckingReleaseUpdates;
         private DateTime _lastPeriodicCheckAttempt = DateTime.MinValue;
         private string _pluginToDelete;
@@ -732,7 +733,8 @@ namespace PluginUpdater
             if (pluginInfo.IsManualInstall)
             {
                 var releaseSources = PluginUpdater.Instance?.Settings.ReleaseSources;
-                var hasSource = releaseSources != null && releaseSources.TryGetValue(pluginInfo.Name, out var releaseUrl) && !string.IsNullOrWhiteSpace(releaseUrl);
+                string releaseUrl = null;
+                var hasSource = releaseSources != null && releaseSources.TryGetValue(pluginInfo.Name, out releaseUrl) && !string.IsNullOrWhiteSpace(releaseUrl);
                 bool isReinstalling = _releaseReinstalling.TryGetValue(pluginInfo.Name, out bool reinstalling) && reinstalling;
 
                 if (hasSource)
@@ -1346,6 +1348,35 @@ namespace PluginUpdater
 
         private static void DeleteDirectory(string directory)
         {
+            const int maxAttempts = 5;
+
+            for (int attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                try
+                {
+                    NormalizeDirectoryAttributes(directory);
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < maxAttempts - 1)
+                {
+                    PluginLogger.Warn($"Failed to delete {directory} on attempt {attempt + 1}: {ex.Message}. Retrying after releasing file handles.");
+                    PluginLifecycleHelper.EnsureAssembliesReleased();
+                    Thread.Sleep(200);
+                }
+            }
+
+            NormalizeDirectoryAttributes(directory);
+            Directory.Delete(directory, true);
+        }
+
+        private static void NormalizeDirectoryAttributes(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
             foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
             {
                 File.SetAttributes(file, FileAttributes.Normal);
@@ -1355,8 +1386,6 @@ namespace PluginUpdater
             {
                 File.SetAttributes(dir, FileAttributes.Normal);
             }
-
-            Directory.Delete(directory, true);
         }
 
         private static string SanitizePluginName(string pluginName)

--- a/PluginUpdater.cs
+++ b/PluginUpdater.cs
@@ -195,5 +195,9 @@ public sealed class PluginUpdater : PCore<PluginUpdaterSettings>
         Settings.ReleaseSources = Settings.ReleaseSources != null
             ? new Dictionary<string, string>(Settings.ReleaseSources, StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Settings.ReleaseChecksums = Settings.ReleaseChecksums != null
+            ? new Dictionary<string, string>(Settings.ReleaseChecksums, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/PluginUpdater.cs
+++ b/PluginUpdater.cs
@@ -199,5 +199,11 @@ public sealed class PluginUpdater : PCore<PluginUpdaterSettings>
         Settings.ReleaseChecksums = Settings.ReleaseChecksums != null
             ? new Dictionary<string, string>(Settings.ReleaseChecksums, StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Settings.ReleaseInstallDirectories = Settings.ReleaseInstallDirectories != null
+            ? new Dictionary<string, string>(Settings.ReleaseInstallDirectories, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Settings.PendingDeletionDirectories ??= new List<string>();
     }
 }

--- a/PluginUpdater.cs
+++ b/PluginUpdater.cs
@@ -1,33 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
-using ExileCore2;
+using GameHelper.Plugin;
+using GameHelper.Settings;
+using ImGuiNET;
+using Newtonsoft.Json;
 
 namespace PluginUpdater;
 
-public class PluginUpdater : BaseSettingsPlugin<PluginUpdaterSettings>
+public sealed class PluginUpdater : PCore<PluginUpdaterSettings>
 {
-    public static PluginUpdater Instance;
-    private Task _startupTask;
+    private const string SettingsFileName = "settings.json";
 
-    public override bool Initialise()
+    public static PluginUpdater Instance { get; private set; }
+
+    private Task _startupTask;
+    private CancellationTokenSource _updateLoopCts;
+    private Task _updateLoopTask;
+    private PluginRenderer _renderer;
+
+    private string PluginDirectory => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory ?? Environment.CurrentDirectory, DllDirectory));
+
+    private string SettingsFilePath => Path.Combine(PluginDirectory, "config", SettingsFileName);
+
+    public override void OnEnable(bool isGameOpened)
     {
         Instance = this;
-        Settings.GameController = GameController;
-        _startupTask = Task.Run(Settings.PluginConfig.Startup);
-        return true;
+        LoadSettings();
+
+        var pluginsRoot = State.PluginsDirectory.FullName;
+        _renderer = new PluginRenderer(Settings, pluginsRoot);
+
+        _startupTask = Task.Run(_renderer.Startup);
+
+        _updateLoopCts = new CancellationTokenSource();
+        _updateLoopTask = Task.Run(() => RunUpdateLoopAsync(_updateLoopCts.Token));
     }
 
-    public override void Render()
+    public override void OnDisable()
     {
-        if (_startupTask == null || !_startupTask.IsCompletedSuccessfully)
-        {
-            if (_startupTask?.IsFaulted == true)
-            {
-                DebugWindow.LogError(_startupTask.Exception.ToString());
-            }
+        SaveSettings();
 
+        _updateLoopCts?.Cancel();
+
+        try
+        {
+            _updateLoopTask?.Wait();
+        }
+        catch (AggregateException ex)
+        {
+            PluginLogger.Error($"Error while stopping update loop: {ex.Flatten().InnerException}");
+        }
+
+        if (_startupTask is { IsFaulted: true } task)
+        {
+            PluginLogger.Error($"Startup task failed: {task.Exception}");
+        }
+
+        _renderer?.Dispose();
+        _renderer = null;
+        _startupTask = null;
+        _updateLoopTask = null;
+        _updateLoopCts?.Dispose();
+        _updateLoopCts = null;
+
+        Instance = null;
+    }
+
+    public override void DrawSettings()
+    {
+        if (_renderer == null)
+        {
+            ImGui.Text("Initializing...");
             return;
         }
 
-        Settings.PluginConfig.Update();
+        if (_startupTask == null)
+        {
+            ImGui.Text("Preparing plugin updater...");
+            return;
+        }
+
+        if (!_startupTask.IsCompleted)
+        {
+            ImGui.Text("Loading plugin information...");
+            return;
+        }
+
+        if (_startupTask.IsFaulted)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, new System.Numerics.Vector4(1f, 0.2f, 0.2f, 1f));
+            ImGui.TextWrapped($"Failed to initialize: {_startupTask.Exception?.GetBaseException().Message}");
+            ImGui.PopStyleColor();
+            return;
+        }
+
+        _renderer.DrawSettings();
+    }
+
+    public override void DrawUI()
+    {
+        // No in-game overlay to render.
+    }
+
+    public override void SaveSettings()
+    {
+        SaveSettingsToDisk();
+    }
+
+    private async Task RunUpdateLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (_startupTask != null)
+            {
+                await _startupTask.ConfigureAwait(false);
+            }
+
+            if (_startupTask is { IsCompletedSuccessfully: true })
+            {
+                _renderer?.Update();
+            }
+
+            using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
+
+            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (_startupTask is { IsCompletedSuccessfully: true })
+                {
+                    _renderer?.Update();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when disabling the plugin.
+        }
+        catch (Exception ex)
+        {
+            PluginLogger.Error($"Update loop failed: {ex}");
+        }
+    }
+
+    private void LoadSettings()
+    {
+        try
+        {
+            var path = SettingsFilePath;
+            if (File.Exists(path))
+            {
+                var json = File.ReadAllText(path);
+                var loaded = JsonConvert.DeserializeObject<PluginUpdaterSettings>(json);
+                if (loaded != null)
+                {
+                    Settings = loaded;
+                    EnsureSettingsInitialized();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginLogger.Error($"Failed to load settings: {ex}");
+            Settings = new PluginUpdaterSettings();
+            EnsureSettingsInitialized();
+        }
+
+        EnsureSettingsInitialized();
+    }
+
+    private void SaveSettingsToDisk()
+    {
+        try
+        {
+            var path = SettingsFilePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var json = JsonConvert.SerializeObject(Settings, Formatting.Indented);
+            File.WriteAllText(path, json);
+        }
+        catch (Exception ex)
+        {
+            PluginLogger.Error($"Failed to save settings: {ex}");
+        }
+    }
+
+    private void EnsureSettingsInitialized()
+    {
+        if (Settings == null)
+        {
+            Settings = new PluginUpdaterSettings();
+        }
+
+        Settings.ReleaseSources = Settings.ReleaseSources != null
+            ? new Dictionary<string, string>(Settings.ReleaseSources, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/PluginUpdater.csproj
+++ b/PluginUpdater.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <UseWindowsForms>true</UseWindowsForms>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>

--- a/PluginUpdater.csproj
+++ b/PluginUpdater.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Rather than replacing this with absolute or relative paths, you should create an environment variable for wherever your HUD folder is-->
-    <Reference Include="ExileCore2">
-      <HintPath>$(exileCore2Package)\ExileCore2.dll</HintPath>
+    <Reference Include="GameHelper">
+      <HintPath>$(gameHelper2Package)\GameHelper.dll</HintPath>
     </Reference>
-    <Reference Include="GameOffsets2">
-      <HintPath>$(exileCore2Package)\GameOffsets2.dll</HintPath>
+    <Reference Include="GameOffsets">
+      <HintPath>$(gameHelper2Package)\GameOffsets.dll</HintPath>
       <Private></Private>
     </Reference>
   </ItemGroup>

--- a/PluginUpdaterSettings.cs
+++ b/PluginUpdaterSettings.cs
@@ -23,6 +23,9 @@ public class PluginUpdaterSettings
     public Dictionary<string, string> ReleaseSources { get; set; }
         = new(StringComparer.OrdinalIgnoreCase);
 
+    public Dictionary<string, string> ReleaseChecksums { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+
     [JsonIgnore]
     public DateTime LastUpdateCheck { get; set; } = DateTime.Now;
 

--- a/PluginUpdaterSettings.cs
+++ b/PluginUpdaterSettings.cs
@@ -27,6 +27,12 @@ public class PluginUpdaterSettings : IPSettings
     public Dictionary<string, string> ReleaseChecksums { get; set; }
         = new(StringComparer.OrdinalIgnoreCase);
 
+    public Dictionary<string, string> ReleaseInstallDirectories { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public List<string> PendingDeletionDirectories { get; set; }
+        = new();
+
     [JsonIgnore]
     public DateTime LastUpdateCheck { get; set; } = DateTime.Now;
 

--- a/PluginUpdaterSettings.cs
+++ b/PluginUpdaterSettings.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using GameHelper.Plugin;
 
 namespace PluginUpdater;
 
-public class PluginUpdaterSettings
+public class PluginUpdaterSettings : IPSettings
 {
     public bool Enable { get; set; } = true;
 

--- a/PluginUpdaterSettings.cs
+++ b/PluginUpdaterSettings.cs
@@ -1,54 +1,43 @@
-﻿using System;
-using ExileCore2;
-using ExileCore2.Shared.Attributes;
-using ExileCore2.Shared.Interfaces;
-using ExileCore2.Shared.Nodes;
+using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace PluginUpdater;
 
-public class PluginUpdaterSettings : ISettings
+public class PluginUpdaterSettings
 {
-    public PluginUpdaterSettings()
-    {
-        PluginConfig = new PluginRenderer(this);
-    }
+    public bool Enable { get; set; } = true;
 
-    public ToggleNode Enable { get; set; } = new ToggleNode(true);
-
-    [IgnoreMenu]
     public bool CheckUpdatesOnStartup { get; set; }
+        = false;
 
-    [IgnoreMenu]
     public bool AutoCheckUpdates { get; set; }
+        = false;
 
-    [IgnoreMenu]
-    public bool WrapLogMessages { get; set; } = true;
+    public bool WrapLogMessages { get; set; }
+        = true;
 
-    [IgnoreMenu]
-    public int UpdateCheckIntervalMinutes { get; set; } = 60;
+    public int UpdateCheckIntervalMinutes { get; set; }
+        = 60;
+
+    public Dictionary<string, string> ReleaseSources { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
 
     [JsonIgnore]
-    [IgnoreMenu]
     public DateTime LastUpdateCheck { get; set; } = DateTime.Now;
 
     [JsonIgnore]
-    [IgnoreMenu]
-    public bool HasCheckedUpdates { get; set; } = false;
-
-    [JsonIgnore]
-    public PluginRenderer PluginConfig { get; set; }
-
-    [JsonIgnore]
-    public GameController GameController { get; set; } // this is very lazy
+    public bool HasCheckedUpdates { get; set; }
+        = false;
 
     public bool ShouldPerformPeriodicCheck()
     {
         if (!AutoCheckUpdates)
+        {
             return false;
+        }
 
         var timeSinceLastCheck = DateTime.Now - LastUpdateCheck;
         return timeSinceLastCheck.TotalMinutes >= UpdateCheckIntervalMinutes;
     }
 }
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Usage**
 
-The "Add" tab now supports Git repositories as well as GitHub release links (for example `https://github.com/derekShaheen/Aura-Tracker-Gamehelper2/releases` or a direct release asset URL). Release archives are automatically extracted into the `Plugins` folder and remembered so they can be re-downloaded later from the Manage tab.
+The "Add" tab now supports Git repositories as well as GitHub release links (for example `https://github.com/derekShaheen/Aura-Tracker-Gamehelper2/releases` or a direct release asset URL). Release archives are automatically extracted into the `Plugins` folder and remembered so they can be re-downloaded later from the Manage tab. When a release is installed the updater stores the archive checksum so that future update checks can redownload the latest release and alert you when a new checksum is published.
 
 **Preview**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **Usage**
 
-The "Add" tab now supports both regular github urls `https://github.com/doubleespressobro/WheresMyZoom/` and branch specific urls `https://github.com/doubleespressobro/WheresMyZoom/tree/poe2`
+The "Add" tab now supports Git repositories as well as GitHub release links (for example `https://github.com/derekShaheen/Aura-Tracker-Gamehelper2/releases` or a direct release asset URL). Release archives are automatically extracted into the `Plugins` folder and remembered so they can be re-downloaded later from the Manage tab.
 
 **Preview**
 
@@ -15,10 +15,6 @@ Manage Tab
 Add Tab
 
 ![image](https://github.com/user-attachments/assets/98cea130-5dd2-47c5-96e0-d490ecd436ce)
-
-Browse Tab
-
-![image](https://github.com/user-attachments/assets/df88735b-94f6-4a1a-a00c-04a8b32b7a77)
 
 Settings Tab
 


### PR DESCRIPTION
## Summary
- replace the community browsing tab with a release-focused add flow that can download GitHub release archives and unzip them into the plugins folder
- persist release source URLs for installed plugins, allow redownloading from the Manage tab, and unload plugins before file operations
- keep manual installs visible in the manager, remove outdated browsing settings, and update documentation for the new workflow

## Testing
- `dotnet build PluginUpdater.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de1f3e4a188331bca6d71f6f4139c2